### PR TITLE
Fe/sistemazione catene ref

### DIFF
--- a/src/frontend/components/dialog.js
+++ b/src/frontend/components/dialog.js
@@ -64,6 +64,26 @@ export class Dialog extends LitElement {
     `;
   }
 
+  // Getters & Setters
+
+  getIsOpened() {
+    return this.isOpened;
+  }
+
+  setIsOpened(value) {
+    this.isOpened = value;
+  }
+
+  getOffsetWidth() {
+    return this.dialogRef.value.offsetWidth;
+  }
+
+  getOffsetHeight() {
+    return this.dialogRef.value.offsetHeight;
+  }
+
+  // -----------------------------
+
   willUpdate(changed) {
     if (changed.has("isOpened") && this.type === "modal")
       this.isOpened
@@ -74,14 +94,6 @@ export class Dialog extends LitElement {
       this.isOpened
         ? this.dialogRef.value.show()
         : this.dialogRef.value.close();
-  }
-
-  openDialog() {
-    this.isOpened = true;
-  }
-
-  closeDialog() {
-    this.isOpened = false;
   }
 }
 customElements.define("il-dialog", Dialog);

--- a/src/frontend/components/input-search.js
+++ b/src/frontend/components/input-search.js
@@ -11,14 +11,14 @@ import "./input-with-icon";
 export class InputRicerca extends LitElement {
   constructor() {
     super();
-    this.inputRef = createRef();
+    this.inputWithIconRef = createRef();
   }
 
   render() {
     return html`
       <il-input-with-icon
-        ${ref(this.inputRef)}
-        .iconName=${this.inputRef.value?.value
+        ${ref(this.inputWithIconRef)}
+        .iconName=${this.getInputWithIconRefValue()
           ? IconNames.close
           : IconNames.magnify}
         @input=${this.onInput}
@@ -28,19 +28,35 @@ export class InputRicerca extends LitElement {
     `;
   }
 
+  //  Getters & Setters
+
+  getInputWithIconRefValue() {
+    return this.inputWithIconRef.value?.getInputValue();
+  }
+
+  setInputWithIconRefValue(value) {
+    this.inputWithIconRef.value?.setInputValue(value);
+  }
+
+  //  --------------------
+
   clear() {
-    this.inputRef.value?.clear();
+    this.inputWithIconRef.value?.clear();
+  }
+
+  focusInput() {
+    this.inputWithIconRef.value?.focusInput();
   }
 
   onIconClick() {
-    const inputValue = this.inputRef.value?.getInputValue();
+    const inputValue = this.getInputWithIconRefValue();
 
     if (inputValue?.length !== 0) {
       this.clear();
       this.search();
       this.requestUpdate();
     } else {
-      this.inputRef.value?.focusInput();
+      this.focusInput();
     }
   }
 
@@ -49,20 +65,16 @@ export class InputRicerca extends LitElement {
     this.requestUpdate();
   }
 
-  getInputValue() {
-    this.inputRef.value?.getInputValue();
-  }
-
   search() {
     this.dispatchEvent(
       new CustomEvent("search", {
         detail: {
-          query: this.inputRef.value?.getInputValue(),
+          query: this.inputWithIconRef.value?.getInputValue(),
         },
       })
     );
 
-    this.inputRef.value?.focus();
+    this.focusInput();
   }
 }
 

--- a/src/frontend/components/input-with-icon.js
+++ b/src/frontend/components/input-with-icon.js
@@ -77,6 +77,35 @@ export class InputWithIcon extends InputField {
     `;
   }
 
+  // Funzioni ereditate da Input-Field
+
+  firstUpdated() {
+    super.firstUpdated();
+  }
+
+  setValue(e) {
+    super.setValue(e);
+  }
+
+  clear() {
+    super.clear();
+  }
+
+  // ----------------------
+
+  // Getters & Setters
+
+  getInputValue() {
+    return this.inputRef.value.value;
+  }
+
+  setInputValue(text) {
+    this.value = text;
+    this.inputRef.value.value = text;
+  }
+
+  // ------------------------
+
   focusInput() {
     this.inputRef.value?.focus();
   }
@@ -87,15 +116,6 @@ export class InputWithIcon extends InputField {
 
   iconClick() {
     this.dispatchEvent(new CustomEvent("icon-click"));
-  }
-
-  setInputValue(text) {
-    this.value = text;
-    this.inputRef.value.value = text;
-  }
-
-  getInputValue() {
-    return this.inputRef.value.value;
   }
 }
 

--- a/src/frontend/components/modal.js
+++ b/src/frontend/components/modal.js
@@ -30,17 +30,35 @@ export class Modal extends LitElement {
     `;
   }
 
+  // Getter & Setters
+
+  getDialogRefIsOpened() {
+    return this.ilDialogRef.value?.getIsOpened();
+  }
+
+  setDialogRefIsOpened(value) {
+    this.ilDialogRef.value?.setIsOpened(value);
+  }
+
+  getDialogRefOffsetWidth() {
+    return this.dialogRef.value?.getOffsetWidth();
+  }
+
+  getDialogRefOffsetHeight() {
+    return this.dialogRef.value?.getOffsetHeight();
+  }
+
+  // ------------------------------
+
   onKeyDown(e) {
-    if (e.key == esc) this.ilDialogRef.value.isOpened = false;
+    if (e.key == esc) this.setDialogRefIsOpened(false);
   }
 
   isClickOuter(event) {
     if (event.detail.x < 0) return true;
-    if (event.detail.x > this.ilDialogRef.value.dialogRef.value.offsetWidth)
-      return true;
+    if (event.detail.x > this.getDialogRefOffsetWidth()) return true;
     if (event.detail.y < 0) return true;
-    if (event.detail.y > this.ilDialogRef.value.dialogRef.value.offsetHeight)
-      return true;
+    if (event.detail.y > this.getDialogRefOffsetHeight()) return true;
 
     return false;
   }
@@ -48,16 +66,8 @@ export class Modal extends LitElement {
   handleClick(event) {
     if (this.closeByBackdropClick && this.isClickOuter(event)) {
       this.dispatchEvent(new CustomEvent("modal-closed"));
-      this.ilDialogRef.value.isOpened = false;
+      this.setDialogRefIsOpened(false);
     }
-  }
-
-  openModal() {
-    this.ilDialogRef.value?.openDialog();
-  }
-
-  closeModal() {
-    this.ilDialogRef.value?.closeDialog();
   }
 }
 

--- a/src/frontend/components/popover.js
+++ b/src/frontend/components/popover.js
@@ -43,11 +43,11 @@ export class Popover extends LitElement {
   }
 
   handleClick() {
-    this.ilDialogRef.value.isOpened = true;
+    this.ilDialogRef.value?.setIsOpened(true);
   }
 
   handleLeave() {
-    if (this.leaveByDefault) this.ilDialogRef.value.isOpened = false;
+    if (this.leaveByDefault) this.ilDialogRef.value?.setIsOpened(false);
   }
 }
 customElements.define("il-popover", Popover);

--- a/src/frontend/pages/app.js
+++ b/src/frontend/pages/app.js
@@ -1,43 +1,39 @@
 import { LitElement, html } from "lit";
 import "./login/login.js";
 import "./chat/chat.js";
-import { ref, createRef } from 'lit/directives/ref.js';
-
 export class App extends LitElement {
-	static get properties() {
-		return {
-			login: {
-				username: "",
-				password: "",
-				headerName: "",
-				token: "",
-			},
-			chatRef: {type: Object}
-		};
-	}
+  static get properties() {
+    return {
+      login: {
+        username: "",
+        password: "",
+        headerName: "",
+        token: "",
+      },
+    };
+  }
 
-	constructor() {
-		super();
-		this.login = {
-			username: "",
-			password: "",
-			headerName: "",
-			token: "",
-		};
-		this.chatRef = createRef()
-	}
+  constructor() {
+    super();
+    this.login = {
+      username: "",
+      password: "",
+      headerName: "",
+      token: "",
+    };
+  }
 
-	render() {
-		return html`
-			${this.login.username === ""
-				? html` <il-login @login-confirm="${this.loginConfirm}"></il-login> `
-				: html` <il-chat .login=${this.login  } ${ref(this.chatRef)} .chatRef=${this.chatRef}></il-chat> `}
-		`; 
-	}
+  render() {
+    return html`
+      ${this.login.username === ""
+        ? html` <il-login @login-confirm="${this.loginConfirm}"></il-login> `
+        : html` <il-chat .login=${this.login}></il-chat> `}
+    `;
+  }
 
-	loginConfirm(e) {
-		this.login = e.detail.login;
-	}
+  loginConfirm(e) {
+    this.login = e.detail.login;
+  }
 }
 
 customElements.define("il-app", App);

--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -62,7 +62,6 @@ export class Chat extends LitElement {
     });
 
     // Refs
-    this.forwardListConversationListRef = createRef();
     this.forwardListRef = createRef();
     this.sidebarRef = createRef();
     this.scrollButtonRef = createRef();
@@ -193,7 +192,6 @@ export class Chat extends LitElement {
                     .messages=${this.messages}
                     .activeChatName=${this.activeChatName}
                     .activeDescription=${this.activeDescription}
-                    .chatRef=${this.chatRef}
                     @forward-message=${this.openForwardMenu}
                     @go-to-chat=${this.goToChat}
                     @message-copy=${() =>
@@ -212,10 +210,9 @@ export class Chat extends LitElement {
                   >
                     <div class="forward-list">
                       ${when(
-                        this.forwardListRef.value?.ilDialogRef.value.isOpened,
+                        this.getForwardListRefIsOpened(),
                         () =>
                           html`<il-conversation-list
-                            ${ref(this.forwardListConversationListRef)}
                             isForwardList="true"
                             @multiple-forward=${this.multipleForward}
                             @change-conversation=${(event) => {
@@ -240,7 +237,7 @@ export class Chat extends LitElement {
                         <il-button-text
                           text="Annulla"
                           @click=${() =>
-                            this.deletionConfirmationDialogRef.value?.closeModal()}
+                            this.setDeletionConfirmationDialogRef(false)}
                         ></il-button-text>
                         <il-button-text
                           color="#DC2042"
@@ -273,6 +270,26 @@ export class Chat extends LitElement {
     `;
   }
 
+  // getters & setters
+
+  getForwardListRefIsOpened() {
+    return this.forwardListRef.value?.getDialogRefIsOpened();
+  }
+
+  setForwardListRefIsOpened(value) {
+    this.forwardListRef.value?.setDialogRefIsOpened(value);
+  }
+
+  getDeletionConfirmationDialogRef() {
+    this.deletionConfirmationDialogRef.value?.getDialogRefIsOpened();
+  }
+
+  setDeletionConfirmationDialogRef(value) {
+    this.deletionConfirmationDialogRef.value?.setDialogRefIsOpened(value);
+  }
+
+  // -------------------------------------
+
   multipleForward(event) {
     if (event.detail.list[0] == undefined) return;
 
@@ -295,18 +312,18 @@ export class Chat extends LitElement {
       });
     }
 
-    this.forwardListRef.value?.closeModal();
+    this.setForwardListRefIsOpened(false);
   }
 
   openForwardMenu(event) {
     this.messageToForward = event.detail.messageToForward;
-    this.forwardListRef.value?.openModal();
+    this.setForwardListRefIsOpened(true);
     this.requestUpdate();
   }
 
   forwardMessage(event) {
     // chiudo il menù di inoltro
-    this.forwardListRef.value?.closeModal();
+    this.setForwardListRefIsOpened(false);
 
     // apro la chat a cui devo inoltrare
     this.setActiveChat(event);
@@ -359,7 +376,7 @@ export class Chat extends LitElement {
 
   askDeletionConfirmation(event) {
     this.indexToBeDeleted = event.detail.index;
-    this.deletionConfirmationDialogRef.value?.openModal();
+    this.setDeletionConfirmationDialogRef(true);
   }
 
   deleteMessage() {
@@ -368,7 +385,7 @@ export class Chat extends LitElement {
       hasBeenDeleted: true,
     };
     this.messagesListRef.value?.requestUpdate();
-    this.deletionConfirmationDialogRef.value?.closeModal();
+    this.setDeletionConfirmationDialogRef(false);
   }
 
   editMessage(event) {

--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -237,7 +237,9 @@ export class Chat extends LitElement {
                         <il-button-text
                           text="Annulla"
                           @click=${() =>
-                            this.setDeletionConfirmationDialogRef(false)}
+                            this.setDeletionConfirmationDialogRefIsOpened(
+                              false
+                            )}
                         ></il-button-text>
                         <il-button-text
                           color="#DC2042"
@@ -280,15 +282,39 @@ export class Chat extends LitElement {
     this.forwardListRef.value?.setDialogRefIsOpened(value);
   }
 
-  getDeletionConfirmationDialogRef() {
-    this.deletionConfirmationDialogRef.value?.getDialogRefIsOpened();
+  getSidebarRefActiveChatName() {
+    return this.sidebarRef.value?.getSidebarListRefActiveChatName();
   }
 
-  setDeletionConfirmationDialogRef(value) {
+  setSidebarRefActiveChatName(value) {
+    this.sidebarRef.value?.setSidebarListRefActiveChatName(value);
+  }
+
+  getSidebarRefActiveDescription() {
+    return this.sidebarRef.value?.getSidebarListRefActiveDescription();
+  }
+
+  setSidebarRefActiveDescription(value) {
+    this.sidebarRef.value?.setSidebarListRefActiveDescription(value);
+  }
+
+  getSidebarRefConversationList() {
+    return [...this.sidebarRef.value?.getSidebarListRefConversationList()];
+  }
+
+  getSidebarRefNewConversationList() {
+    return [...this.sidebarRef.value?.getSidebarListRefNewConversationList()];
+  }
+
+  setDeletionConfirmationDialogRefIsOpened(value) {
     this.deletionConfirmationDialogRef.value?.setDialogRefIsOpened(value);
   }
 
   // -------------------------------------
+
+  setList(message) {
+    this.sidebarRef.value?.setList(message);
+  }
 
   multipleForward(event) {
     if (event.detail.list[0] == undefined) return;
@@ -329,10 +355,8 @@ export class Chat extends LitElement {
     this.setActiveChat(event);
     this.updateMessages(event);
 
-    this.sidebarRef.value.sidebarListRef.value.activeChatName =
-      event.detail.conversation.roomName;
-    this.sidebarRef.value.sidebarListRef.value.activeDescription =
-      event.detail.conversation.description;
+    this.setSidebarRefActiveChatName(event.detail.conversation.roomName);
+    this.setSidebarRefActiveDescription(event.detail.conversation.description);
 
     // invio il messaggio
     this.sendMessage({ detail: { message: this.messageToForward } });
@@ -341,10 +365,9 @@ export class Chat extends LitElement {
   }
 
   goToChat(event) {
-    let list = this.sidebarRef.value.sidebarListRef.value.conversationList;
+    let list = this.getSidebarRefConversationList();
 
-    let newList =
-      this.sidebarRef.value.sidebarListRef.value.newConversationList;
+    let newList = this.getSidebarListRefNewConversationList();
 
     let index = list.findIndex((elem) => {
       return this.isUsernameInRoomName(elem.roomName, event.detail.description);
@@ -358,17 +381,13 @@ export class Chat extends LitElement {
         );
       });
 
-      this.sidebarRef.value.sidebarListRef.value.activeChatName =
-        newList[index].roomName;
-      this.sidebarRef.value.sidebarListRef.value.activeDescription =
-        newList[index].description;
+      this.setSidebarRefActiveChatName(newList[index].roomName);
+      this.setSidebarRefActiveDescription(newList[index].description);
 
       this.updateMessages({ detail: { conversation: newList[index] } });
     } else {
-      this.sidebarRef.value.sidebarListRef.value.activeChatName =
-        list[index].roomName;
-      this.sidebarRef.value.sidebarListRef.value.activeDescription =
-        list[index].description;
+      this.setSidebarRefActiveChatName(list[index].roomName);
+      this.setSidebarRefActiveDescription(list[index].description);
 
       this.updateMessages({ detail: { conversation: list[index] } });
     }
@@ -376,7 +395,7 @@ export class Chat extends LitElement {
 
   askDeletionConfirmation(event) {
     this.indexToBeDeleted = event.detail.index;
-    this.setDeletionConfirmationDialogRef(true);
+    this.setDeletionConfirmationDialogRefIsOpened(true);
   }
 
   deleteMessage() {
@@ -385,7 +404,7 @@ export class Chat extends LitElement {
       hasBeenDeleted: true,
     };
     this.messagesListRef.value?.requestUpdate();
-    this.setDeletionConfirmationDialogRef(false);
+    this.setDeletionConfirmationDialogRefIsOpened(false);
   }
 
   editMessage(event) {
@@ -402,8 +421,7 @@ export class Chat extends LitElement {
       hasBeenEdited: true,
     };
 
-    if (index === this.messages.length - 1)
-      this.sidebarRef.value.sidebarListRef.value.setList(message);
+    if (index === this.messages.length - 1) this.setList(message);
 
     this.messagesListRef.value?.requestUpdate();
   }
@@ -572,7 +590,7 @@ export class Chat extends LitElement {
         this.requestUpdate();
       }
 
-      this.sidebarRef.value.sidebarListRef.value.setList(message);
+      this.setList(message);
     }
 
     this.messageNotification(message);

--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -65,7 +65,6 @@ export class Chat extends LitElement {
     this.forwardListRef = createRef();
     this.sidebarRef = createRef();
     this.scrollButtonRef = createRef();
-    this.messageBoxRef = createRef();
     this.inputControlsRef = createRef();
     this.messagesListRef = createRef();
     this.snackbarRef = createRef();

--- a/src/frontend/pages/chat/message/message-menu-popover.js
+++ b/src/frontend/pages/chat/message/message-menu-popover.js
@@ -43,7 +43,6 @@ export class MessageMenuPopover extends LitElement {
         <il-message-options
           slot="popup"
           @message-copy=${this.messageCopy}
-          .chatRef=${this.chatRef}
           .message=${this.message}
           .cookie=${this.cookie}
           .index=${this.index}

--- a/src/frontend/pages/chat/message/message.js
+++ b/src/frontend/pages/chat/message/message.js
@@ -105,7 +105,6 @@ export class Message extends LitElement {
             <il-message-menu-popover
               style="opacity: 0"
               ${ref(this.messageMenuPopoverRef)}
-              .chatRef=${this.chatRef}
               @message-copy=${this.messageCopy}
               .messages=${this.messages}
               .message=${this.message}

--- a/src/frontend/pages/chat/message/messages-list.js
+++ b/src/frontend/pages/chat/message/messages-list.js
@@ -96,7 +96,6 @@ export class MessagesList extends LitElement {
                 .index=${index}
                 .activeChatName=${this.activeChatName}
                 .activeDescription=${this.activeDescription}
-                .chatRef=${this.chatRef}
                 @message-copy=${this.messageCopy}
                 @forward-message=${(event) => {
                   this.dispatchEvent(

--- a/src/frontend/pages/chat/sidebar/conversation/conversation-list.js
+++ b/src/frontend/pages/chat/sidebar/conversation/conversation-list.js
@@ -51,6 +51,8 @@ class ConversationList extends LitElement {
     this.selectedRoom = {};
     this.selectedChats = [];
     this.isOpen = false;
+
+    // Refs
     this.inputRef = createRef();
   }
 
@@ -168,6 +170,110 @@ class ConversationList extends LitElement {
       </div>
     `;
   }
+
+  renderConversationList() {
+    this.conversationListFiltered = this.filterConversations(
+      this.conversationList
+    );
+
+    if (this.conversationListFiltered.length === 0) return noResult;
+
+    return repeat(this.conversationListFiltered, (pharmacy) => {
+      let conversation = new ConversationDto(pharmacy);
+
+      if (
+        conversation.lastMessage?.content ||
+        conversation.roomName == this.activeChatName
+      ) {
+        let user = this.findUser(this.conversationListFiltered, conversation);
+
+        return html`<il-conversation
+          .userList=${this.usersList}
+          .user=${user}
+          @selected=${this.selectConversation}
+          .isSelectable=${this.isForwardList && this.selectedChats.length != 0}
+          .isSelected=${this.selectedChats.includes(conversation.roomName)}
+          class=${"conversation " +
+          (conversation.roomName == this.activeChatName ||
+          conversation.roomName == this.selectedRoom.roomName
+            ? "active"
+            : "")}
+          id=${conversation.roomName == this.selectedRoom.roomName
+            ? "selected"
+            : ""}
+          .chat=${conversation}
+          @clicked=${(event) => this.handleClick(event, conversation)}
+        ></il-conversation>`;
+      } else {
+        let conversationIndex = this.conversationList.findIndex(
+          (obj) => obj.roomName == conversation.roomName
+        );
+        let delChat = this.conversationList.splice(conversationIndex, 1)[0];
+        this.newConversationList.unshift(delChat);
+        return null;
+      }
+    });
+  }
+
+  renderNewConversationList() {
+    this.newConversationListFiltered = this.filterConversations(
+      this.newConversationList
+    );
+
+    if (this.newConversationListFiltered.length === 0) return noResult;
+
+    return this.newConversationListFiltered.map((pharmacy) => {
+      let conversation = new ConversationDto(pharmacy);
+
+      let user = this.findUser(this.newConversationListFiltered, conversation);
+
+      return html`<il-conversation
+        .userList=${this.usersList}
+        .user=${user}
+        @selected=${this.selectConversation}
+        .isSelectable=${this.isForwardList && this.selectedChats.length != 0}
+        .isSelected=${this.selectedChats.includes(conversation.roomName)}
+        class=${"conversation new-conversation " +
+        (conversation.roomName == this.activeChatName ||
+        conversation.roomName == this.selectedRoom.roomName
+          ? "active"
+          : "")}
+        .chat=${conversation}
+        id=${conversation.roomName == this.selectedRoom.roomName
+          ? "selected"
+          : ""}
+        @clicked=${(event) => this.handleClick(event, conversation)}
+      ></il-conversation>`;
+    });
+  }
+
+  // Getters & Setters
+
+  getActiveChatName() {
+    return this.activeChatName;
+  }
+
+  setActiveChatName(value) {
+    this.activeChatName = value;
+  }
+
+  getActiveDescription() {
+    return this.activeDescription;
+  }
+
+  setActiveDescription(value) {
+    this.activeDescription = value;
+  }
+
+  getConversationList() {
+    return [...this.conversationList];
+  }
+
+  getNewConversationList() {
+    return [...this.newConversationList];
+  }
+
+  // -----------------------------
 
   navigateSearchResultsWithArrows(e) {
     if (e.detail.key == arrowDown || e.detail.key == arrowUp)
@@ -389,82 +495,6 @@ class ConversationList extends LitElement {
     var timestampA = Date.parse(a.lastMessage?.timestamp);
     var timestampB = Date.parse(b.lastMessage?.timestamp);
     return timestampB - timestampA;
-  }
-
-  renderConversationList() {
-    this.conversationListFiltered = this.filterConversations(
-      this.conversationList
-    );
-
-    if (this.conversationListFiltered.length === 0) return noResult;
-
-    return repeat(this.conversationListFiltered, (pharmacy) => {
-      let conversation = new ConversationDto(pharmacy);
-
-      if (
-        conversation.lastMessage?.content ||
-        conversation.roomName == this.activeChatName
-      ) {
-        let user = this.findUser(this.conversationListFiltered, conversation);
-
-        return html`<il-conversation
-          .userList=${this.usersList}
-          .user=${user}
-          @selected=${this.selectConversation}
-          .isSelectable=${this.isForwardList && this.selectedChats.length != 0}
-          .isSelected=${this.selectedChats.includes(conversation.roomName)}
-          class=${"conversation " +
-          (conversation.roomName == this.activeChatName ||
-          conversation.roomName == this.selectedRoom.roomName
-            ? "active"
-            : "")}
-          id=${conversation.roomName == this.selectedRoom.roomName
-            ? "selected"
-            : ""}
-          .chat=${conversation}
-          @clicked=${(event) => this.handleClick(event, conversation)}
-        ></il-conversation>`;
-      } else {
-        let conversationIndex = this.conversationList.findIndex(
-          (obj) => obj.roomName == conversation.roomName
-        );
-        let delChat = this.conversationList.splice(conversationIndex, 1)[0];
-        this.newConversationList.unshift(delChat);
-        return null;
-      }
-    });
-  }
-
-  renderNewConversationList() {
-    this.newConversationListFiltered = this.filterConversations(
-      this.newConversationList
-    );
-
-    if (this.newConversationListFiltered.length === 0) return noResult;
-
-    return this.newConversationListFiltered.map((pharmacy) => {
-      let conversation = new ConversationDto(pharmacy);
-
-      let user = this.findUser(this.newConversationListFiltered, conversation);
-
-      return html`<il-conversation
-        .userList=${this.usersList}
-        .user=${user}
-        @selected=${this.selectConversation}
-        .isSelectable=${this.isForwardList && this.selectedChats.length != 0}
-        .isSelected=${this.selectedChats.includes(conversation.roomName)}
-        class=${"conversation new-conversation " +
-        (conversation.roomName == this.activeChatName ||
-        conversation.roomName == this.selectedRoom.roomName
-          ? "active"
-          : "")}
-        .chat=${conversation}
-        id=${conversation.roomName == this.selectedRoom.roomName
-          ? "selected"
-          : ""}
-        @clicked=${(event) => this.handleClick(event, conversation)}
-      ></il-conversation>`;
-    });
   }
 
   findUser(list, conversation) {

--- a/src/frontend/pages/chat/sidebar/search-chats.js
+++ b/src/frontend/pages/chat/sidebar/search-chats.js
@@ -152,7 +152,7 @@ export class SearchChats extends LitElement {
   }
 
   getInputValue() {
-    this.inputRef.value?.getInputValue();
+    this.inputRef.value?.getInputWithIconRefValue();
   }
 
   searchChat(event) {

--- a/src/frontend/pages/chat/sidebar/sidebar.js
+++ b/src/frontend/pages/chat/sidebar/sidebar.js
@@ -58,6 +58,37 @@ export class Sidebar extends LitElement {
     `;
   }
 
+  // getters & setters
+
+  getSidebarListRefActiveChatName() {
+    return this.sidebarListRef.value?.getActiveChatName();
+  }
+
+  setSidebarListRefActiveChatName(value) {
+    this.sidebarListRef.value?.setActiveChatName(value);
+  }
+
+  getSidebarListRefActiveDescription() {
+    return this.sidebarListRef.value?.getActiveDescription();
+  }
+
+  setSidebarListRefActiveDescription(value) {
+    this.sidebarListRef.value?.setActiveDescription(value);
+  }
+
+  getSidebarListRefConversationList() {
+    return [...this.sidebarListRef.value?.getConversationList()];
+  }
+
+  getSidebarListRefNewConversationList() {
+    return [...this.sidebarListRef.value?.getNewConversationList()];
+  }
+
+  // -----------------------------------
+
+  setList(message) {
+    this.sidebarListRef.value?.setList(message);
+  }
 }
 
 customElements.define("il-sidebar", Sidebar);


### PR DESCRIPTION
Notando che in alcuni file, soprattutto in chat.js, venivano usate catene di ref per impostare le proprietà delle classi figlie ho pensato di fornire per ogni proprietà modificabile dall'esterno un get  e un set (o uno dei due a seconda delle preferenze).
La mia idea è che le proprietà interne ad un componente restino sempre private e che possano essere modificate direttamente solo ad un livello di gerarchia grazie ai get e ai set. Per far sì che una proprietà sia modificabile da un componente in ascesa che superi un livello di gerarchia allora esso dovrà accedere ai metodi get-set del figlio che a loro volta effettueranno lo stesso comportamento fino a raggiungere quelli della proprietà interessata. 