### PR TITLE
Be/username roomname fk

### DIFF
--- a/src/main/java/com/cgm/infolab/db/model/DownloadDateEntity.java
+++ b/src/main/java/com/cgm/infolab/db/model/DownloadDateEntity.java
@@ -6,16 +6,18 @@ import java.util.Objects;
 public class DownloadDateEntity {
     private LocalDateTime timestamp;
     private long userId;
+    private Username username;
     private long messageId;
 
-    private DownloadDateEntity(LocalDateTime timestamp, long userId, long messageId) {
+    private DownloadDateEntity(LocalDateTime timestamp, long userId, Username username, long messageId) {
         this.timestamp = timestamp;
         this.userId = userId;
+        this.username = username;
         this.messageId = messageId;
     }
 
-    public static DownloadDateEntity of(LocalDateTime timestamp, long userId, long roomId) {
-        return new DownloadDateEntity(timestamp, userId, roomId);
+    public static DownloadDateEntity of(LocalDateTime timestamp, long userId, Username username, long roomId) {
+        return new DownloadDateEntity(timestamp, userId, username, roomId);
     }
 
     public LocalDateTime getTimestamp() {
@@ -32,6 +34,14 @@ public class DownloadDateEntity {
 
     public void setUserId(long userId) {
         this.userId = userId;
+    }
+
+    public Username getUsername() {
+        return username;
+    }
+
+    public void setUsername(Username username) {
+        this.username = username;
     }
 
     public long getMessageId() {

--- a/src/main/java/com/cgm/infolab/db/model/RoomSubscriptionEntity.java
+++ b/src/main/java/com/cgm/infolab/db/model/RoomSubscriptionEntity.java
@@ -1,33 +1,21 @@
 package com.cgm.infolab.db.model;
 
-import com.cgm.infolab.db.ID;
+import java.util.Objects;
 
 public class RoomSubscriptionEntity {
-    private long roomId;
     private RoomName roomName;
-    private long userId;
     private Username username;
 
     private RoomSubscriptionEntity() {
     }
 
-    private RoomSubscriptionEntity(long roomId, RoomName roomName, long userId, Username username) {
-        this.roomId = roomId;
+    private RoomSubscriptionEntity(RoomName roomName, Username username) {
         this.roomName = roomName;
-        this.userId = userId;
         this.username = username;
     }
 
     public static RoomSubscriptionEntity empty() {
-        return new RoomSubscriptionEntity(ID.None, RoomName.empty(), ID.None, Username.empty());
-    }
-
-    public long getRoomId() {
-        return roomId;
-    }
-
-    public void setRoomId(long roomId) {
-        this.roomId = roomId;
+        return new RoomSubscriptionEntity(RoomName.empty(), Username.empty());
     }
 
     public RoomName getRoomName() {
@@ -36,14 +24,6 @@ public class RoomSubscriptionEntity {
 
     public void setRoomName(RoomName roomName) {
         this.roomName = roomName;
-    }
-
-    public long getUserId() {
-        return userId;
-    }
-
-    public void setUserId(long userId) {
-        this.userId = userId;
     }
 
     public Username getUsername() {
@@ -57,8 +37,21 @@ public class RoomSubscriptionEntity {
     @Override
     public String toString() {
         return "RoomSubscriptionEntity{" +
-                "roomId=" + roomId +
-                ", userId=" + userId +
-                "}";
+                "roomName=" + roomName +
+                ", username=" + username +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RoomSubscriptionEntity that = (RoomSubscriptionEntity) o;
+        return Objects.equals(roomName, that.roomName) && Objects.equals(username, that.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(roomName, username);
     }
 }

--- a/src/main/java/com/cgm/infolab/db/model/RoomSubscriptionEntity.java
+++ b/src/main/java/com/cgm/infolab/db/model/RoomSubscriptionEntity.java
@@ -4,18 +4,22 @@ import com.cgm.infolab.db.ID;
 
 public class RoomSubscriptionEntity {
     private long roomId;
+    private RoomName roomName;
     private long userId;
+    private Username username;
 
     private RoomSubscriptionEntity() {
     }
 
-    private RoomSubscriptionEntity(long roomId, long userId) {
+    private RoomSubscriptionEntity(long roomId, RoomName roomName, long userId, Username username) {
         this.roomId = roomId;
+        this.roomName = roomName;
         this.userId = userId;
+        this.username = username;
     }
 
     public static RoomSubscriptionEntity empty() {
-        return new RoomSubscriptionEntity(ID.None, ID.None);
+        return new RoomSubscriptionEntity(ID.None, RoomName.empty(), ID.None, Username.empty());
     }
 
     public long getRoomId() {
@@ -26,12 +30,28 @@ public class RoomSubscriptionEntity {
         this.roomId = roomId;
     }
 
+    public RoomName getRoomName() {
+        return roomName;
+    }
+
+    public void setRoomName(RoomName roomName) {
+        this.roomName = roomName;
+    }
+
     public long getUserId() {
         return userId;
     }
 
     public void setUserId(long userId) {
         this.userId = userId;
+    }
+
+    public Username getUsername() {
+        return username;
+    }
+
+    public void setUsername(Username username) {
+        this.username = username;
     }
 
     @Override

--- a/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
@@ -24,7 +24,7 @@ public class ChatMessageRepository {
     private final Logger log = LoggerFactory.getLogger(ChatMessageRepository.class);
 
     private final String JOIN_MESSAGES =
-            "JOIN infolab.chatmessages m ON r.id = m.recipient_room_id";
+            "JOIN infolab.chatmessages m ON r.roomname = m.recipient_room_name";
 
     public ChatMessageRepository(DataSource dataSource, QueryHelper queryHelper) {
         this.dataSource = dataSource;
@@ -39,7 +39,6 @@ public class ChatMessageRepository {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("sender_name", message.getSender().getName().value());
-        parameters.put("recipient_room_id", message.getRoom().getId());
         parameters.put("recipient_room_name", message.getRoom().getName().value());
         parameters.put("sent_at", message.getTimestamp());
         parameters.put("content", message.getContent());

--- a/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
@@ -38,7 +38,6 @@ public class ChatMessageRepository {
                 .usingGeneratedKeyColumns("id");
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("sender_id", message.getSender().getId());
         parameters.put("sender_name", message.getSender().getName().value());
         parameters.put("recipient_room_id", message.getRoom().getId());
         parameters.put("recipient_room_name", message.getRoom().getName().value());
@@ -129,7 +128,7 @@ public class ChatMessageRepository {
     private UserQueryResult getMessages(Username username) {
         return queryHelper
                 .forUser(username)
-                .query("SELECT m.id message_id, m.sender_id user_id, m.sender_name username, m.sender_id, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status")
+                .query("SELECT m.id message_id, m.sender_name username, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status")
                 .join(JOIN_MESSAGES);
     }
 

--- a/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
@@ -38,7 +38,9 @@ public class ChatMessageRepository {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("sender_id", message.getSender().getId());
+        parameters.put("sender_name", message.getSender().getName().value());
         parameters.put("recipient_room_id", message.getRoom().getId());
+        parameters.put("recipient_room_name", message.getRoom().getName().value());
         parameters.put("sent_at", message.getTimestamp());
         parameters.put("content", message.getContent());
         parameters.put("status", message.getStatus());

--- a/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/ChatMessageRepository.java
@@ -24,8 +24,7 @@ public class ChatMessageRepository {
     private final Logger log = LoggerFactory.getLogger(ChatMessageRepository.class);
 
     private final String JOIN_MESSAGES =
-            "LEFT JOIN infolab.chatmessages m ON r.id = m.recipient_room_id";
-    private final String JOIN_MESSAGES_WITH_LOGGED_USER = "%s JOIN infolab.users u_logged ON u_logged.username = :username".formatted(JOIN_MESSAGES);
+            "JOIN infolab.chatmessages m ON r.id = m.recipient_room_id";
 
     public ChatMessageRepository(DataSource dataSource, QueryHelper queryHelper) {
         this.dataSource = dataSource;
@@ -130,8 +129,8 @@ public class ChatMessageRepository {
     private UserQueryResult getMessages(Username username) {
         return queryHelper
                 .forUser(username)
-                .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, m.sender_id, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status")
-                .join("%s LEFT JOIN infolab.users u_mex ON u_mex.id = m.sender_id".formatted(JOIN_MESSAGES));
+                .query("SELECT m.id message_id, m.sender_id user_id, m.sender_name username, m.sender_id, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status")
+                .join(JOIN_MESSAGES);
     }
 
     public int updateMessageAsDeleted(Username username, long idToDelete) {
@@ -142,8 +141,8 @@ public class ChatMessageRepository {
         return queryHelper
                 .forUser(username)
                 .query("UPDATE infolab.chatmessages SET status = 'DELETED' WHERE id IN (select m.id")
-                .join(JOIN_MESSAGES_WITH_LOGGED_USER)
-                .where("m.sender_id = u_logged.id and m.id = :idToDelete")
+                .join(JOIN_MESSAGES)
+                .where("m.sender_name = :username and m.id = :idToDelete")
                 .other(")")
                 .update(params);
     }
@@ -157,8 +156,8 @@ public class ChatMessageRepository {
         return queryHelper
                 .forUser(username)
                 .query("UPDATE infolab.chatmessages SET content = :newContent, status = 'EDITED' WHERE id IN (select m.id")
-                .join(JOIN_MESSAGES_WITH_LOGGED_USER)
-                .where("m.sender_id = u_logged.id and m.id = :idToEdit and (m.status IS NULL or m.status NOT LIKE 'DELETED%')")
+                .join(JOIN_MESSAGES)
+                .where("m.sender_name = :username and m.id = :idToEdit and (m.status IS NULL or m.status NOT LIKE 'DELETED%')")
                 .other(")")
                 .update(params);
     }

--- a/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
@@ -41,6 +41,7 @@ public class DownloadDateRepository {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("timestamp", entity.getTimestamp());
         parameters.put("user_id", entity.getUserId());
+        parameters.put("username", entity.getUsername().value());
         parameters.put("message_id", entity.getMessageId());
         simpleJdbcInsert.execute(parameters);
     }
@@ -55,7 +56,7 @@ public class DownloadDateRepository {
 
         queryHelper
                 .forUser(username)
-                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, message_id) SELECT :timestamp, u_logged.id, m.id")
+                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, username, message_id) SELECT :timestamp, u_logged.id, :username, m.id")
                 .join(DOWNLOAD_DATES_JOIN)
                 .where(DOWNLOAD_DATES_WHERE_NOT_DOWNLOADED_AND_ROOMNAME)
                 .update(arguments);
@@ -71,7 +72,7 @@ public class DownloadDateRepository {
 
         queryHelper
                 .forUser(username)
-                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, message_id) SELECT :timestamp, u_logged.id, m.id")
+                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, username, message_id) SELECT :timestamp, u_logged.id, :username, m.id")
                 .join("join infolab.chatmessages m on m.recipient_room_id = r.id join infolab.users u_logged on u_logged.username = :username")
                 .where("m.id IN (:messageIds)")
                 .update(arguments);

--- a/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
@@ -19,7 +19,7 @@ public class DownloadDateRepository {
 
     protected static final String DOWNLOAD_DATES_JOIN =
             "JOIN infolab.chatmessages m " +
-                    "ON m.recipient_room_id = r.id " +
+                    "ON m.recipient_room_name = r.roomname " +
                     "JOIN infolab.users u_logged " +
                     "ON u_logged.username = :username " +
                     "LEFT JOIN infolab.download_dates d " +
@@ -73,7 +73,7 @@ public class DownloadDateRepository {
         return queryHelper
                 .forUser(username)
                 .query("INSERT INTO infolab.download_dates (download_timestamp, username, message_id) SELECT :timestamp, :username, m.id")
-                .join("join infolab.chatmessages m on m.recipient_room_id = r.id join infolab.users u_logged on u_logged.username = :username")
+                .join("join infolab.chatmessages m on m.recipient_room_name = r.roomname join infolab.users u_logged on u_logged.username = :username")
                 .where("m.id IN (:messageIds)")
                 .update(arguments);
     }

--- a/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
@@ -18,9 +18,9 @@ public class DownloadDateRepository {
     private final DataSource dataSource;
 
     protected static final String DOWNLOAD_DATES_JOIN =
-            "LEFT JOIN infolab.chatmessages m " +
+            "JOIN infolab.chatmessages m " +
                     "ON m.recipient_room_id = r.id " +
-                    "LEFT JOIN infolab.users u_logged " +
+                    "JOIN infolab.users u_logged " +
                     "ON u_logged.username = :username " +
                     "LEFT JOIN infolab.download_dates d " +
                     "ON d.user_id = u_logged.id AND d.message_id = m.id";

--- a/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/DownloadDateRepository.java
@@ -23,7 +23,7 @@ public class DownloadDateRepository {
                     "JOIN infolab.users u_logged " +
                     "ON u_logged.username = :username " +
                     "LEFT JOIN infolab.download_dates d " +
-                    "ON d.user_id = u_logged.id AND d.message_id = m.id";
+                    "ON d.username = u_logged.username AND d.message_id = m.id";
     protected static final String DOWNLOAD_DATES_WHERE_NULL = "d.download_timestamp IS NULL";
     protected static final String DOWNLOAD_DATES_WHERE_NOT_DOWNLOADED_AND_ROOMNAME =
             DOWNLOAD_DATES_WHERE_NULL + " AND r.roomname = :roomName";
@@ -56,7 +56,7 @@ public class DownloadDateRepository {
 
         return queryHelper
                 .forUser(username)
-                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, username, message_id) SELECT :timestamp, u_logged.id, :username, m.id")
+                .query("INSERT INTO infolab.download_dates (download_timestamp, username, message_id) SELECT :timestamp, :username, m.id")
                 .join(DOWNLOAD_DATES_JOIN)
                 .where(DOWNLOAD_DATES_WHERE_NOT_DOWNLOADED_AND_ROOMNAME)
                 .update(arguments);
@@ -72,7 +72,7 @@ public class DownloadDateRepository {
 
         return queryHelper
                 .forUser(username)
-                .query("INSERT INTO infolab.download_dates (download_timestamp, user_id, username, message_id) SELECT :timestamp, u_logged.id, :username, m.id")
+                .query("INSERT INTO infolab.download_dates (download_timestamp, username, message_id) SELECT :timestamp, :username, m.id")
                 .join("join infolab.chatmessages m on m.recipient_room_id = r.id join infolab.users u_logged on u_logged.username = :username")
                 .where("m.id IN (:messageIds)")
                 .update(arguments);

--- a/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
@@ -215,7 +215,7 @@ public class RoomRepository {
         return queryHelper
                 .forUser(username)
                 .query("SELECT DISTINCT ON (r.roomname) r.id room_id, r.roomname, " +
-                        "r.visibility, m.sender_id user_id, m.sender_name username, m.id message_id, m.sent_at, m.content, m.sender_id, m.status, " +
+                        "r.visibility, m.sender_name username, m.id message_id, m.sent_at, m.content, m.status, " +
                         "u_other.id other_user_id, u_other.username other_username, u_other.description other_description, %s".formatted(CASE_QUERY))
                 .join("LEFT JOIN infolab.chatmessages m ON r.id = m.recipient_room_id " +
                         "left join infolab.rooms_subscriptions s_other on r.roomname = s_other.roomname and s_other.username <> s.username " +

--- a/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
@@ -28,8 +28,8 @@ public class RoomRepository {
                 "WHEN r.visibility = 'PUBLIC' THEN r.description " +
                 "ELSE u_other.description " +
             "END AS description";
-    private final String JOIN = "left join infolab.rooms_subscriptions s_other on r.id = s_other.room_id and s_other.user_id <> s.user_id " +
-            "left join infolab.users u_other on u_other.id = s_other.user_id";
+    private final String JOIN = "left join infolab.rooms_subscriptions s_other on r.roomname = s_other.roomname and s_other.username <> s.username " +
+            "left join infolab.users u_other on u_other.username = s_other.username";
 
     private final String ROOMS_AND_LAST_MESSAGES_OTHER = "ORDER BY r.roomname, m.sent_at DESC";
 
@@ -131,7 +131,7 @@ public class RoomRepository {
         return queryHelper
                 .query("SELECT r.id room_id, r.roomname, r.visibility, %s".formatted(CASE_QUERY))
                 .from("infolab.rooms r")
-                .join("left join infolab.rooms_subscriptions s on r.id = s.room_id %s".formatted(JOIN));
+                .join("left join infolab.rooms_subscriptions s on r.roomname = s.roomname %s".formatted(JOIN));
     }
 
     public List<RoomEntity> getAllRoomsAndLastMessageEvenIfNullInPublicRooms(Username username) {
@@ -218,8 +218,8 @@ public class RoomRepository {
                         "r.visibility, m.sender_id user_id, m.sender_name username, m.id message_id, m.sent_at, m.content, m.sender_id, m.status, " +
                         "u_other.id other_user_id, u_other.username other_username, u_other.description other_description, %s".formatted(CASE_QUERY))
                 .join("LEFT JOIN infolab.chatmessages m ON r.id = m.recipient_room_id " +
-                        "left join infolab.rooms_subscriptions s_other on r.id = s_other.room_id and s_other.user_id <> s.user_id " +
-                        "left join infolab.users u_other on u_other.id = s_other.user_id");
+                        "left join infolab.rooms_subscriptions s_other on r.roomname = s_other.roomname and s_other.username <> s.username " +
+                        "left join infolab.users u_other on u_other.username = s_other.username");
     }
 
     public Map<Long, Integer> getNotDownloadedYetNumberGroupedByRoom(List<Long> roomIds, Username username) {

--- a/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
@@ -215,9 +215,9 @@ public class RoomRepository {
         return queryHelper
                 .forUser(username)
                 .query("SELECT DISTINCT ON (r.roomname) r.id room_id, r.roomname, " +
-                        "r.visibility, u_mex.id user_id, u_mex.username username, m.id message_id, m.sent_at, m.content, m.sender_id, m.status, " +
+                        "r.visibility, m.sender_id user_id, m.sender_name username, m.id message_id, m.sent_at, m.content, m.sender_id, m.status, " +
                         "u_other.id other_user_id, u_other.username other_username, u_other.description other_description, %s".formatted(CASE_QUERY))
-                .join("LEFT JOIN infolab.chatmessages m ON r.id = m.recipient_room_id LEFT JOIN infolab.users u_mex ON u_mex.id = m.sender_id " +
+                .join("LEFT JOIN infolab.chatmessages m ON r.id = m.recipient_room_id " +
                         "left join infolab.rooms_subscriptions s_other on r.id = s_other.room_id and s_other.user_id <> s.user_id " +
                         "left join infolab.users u_other on u_other.id = s_other.user_id");
     }

--- a/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomRepository.java
@@ -93,7 +93,7 @@ public class RoomRepository {
     public Optional<RoomEntity> getById(long id, Username username) {
         Map<String, Object> arguments = new HashMap<>();
         arguments.put("roomId", id);
-        return  queryRoom("AND r.id = :roomId", username, arguments);
+        return  queryRoom("r.id = :roomId", username, arguments);
     }
 
     private Optional<RoomEntity> queryRoom(String where, Username username, Map<String, ?> queryParams) {

--- a/src/main/java/com/cgm/infolab/db/repository/RoomSubscriptionRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomSubscriptionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,15 +20,13 @@ public class RoomSubscriptionRepository {
         this.dataSource = dataSource;
     }
 
-    public void add(RoomSubscriptionEntity entity) throws DuplicateKeyException {
+    public void add(RoomSubscriptionEntity entity) throws DuplicateKeyException, SQLIntegrityConstraintViolationException {
         SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
                 .withSchemaName("infolab")
                 .withTableName("rooms_subscriptions");
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("room_id", entity.getRoomId());
         parameters.put("roomname", entity.getRoomName().value());
-        parameters.put("user_id", entity.getUserId());
         parameters.put("username", entity.getUsername().value());
 
         simpleJdbcInsert.execute(parameters);

--- a/src/main/java/com/cgm/infolab/db/repository/RoomSubscriptionRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RoomSubscriptionRepository.java
@@ -26,7 +26,10 @@ public class RoomSubscriptionRepository {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("room_id", entity.getRoomId());
+        parameters.put("roomname", entity.getRoomName().value());
         parameters.put("user_id", entity.getUserId());
+        parameters.put("username", entity.getUsername().value());
+
         simpleJdbcInsert.execute(parameters);
     }
 }

--- a/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
@@ -98,15 +98,15 @@ public abstract class RowMappers {
         );
     }
 
-    public static Pair<String, Integer> mapNotDownloadedMessagesCount(ResultSet rs, int rowNum) throws SQLException {
-        return Pair.of(rs.getString("roomname"), rs.getInt("not_downloaded_count"));
+    public static Pair<RoomName, Integer> mapNotDownloadedMessagesCount(ResultSet rs, int rowNum) throws SQLException {
+        return Pair.of(RoomName.of(rs.getString("roomname")), rs.getInt("not_downloaded_count"));
     }
 
-    public static Pair<String, LocalDateTime> mapLastDownloadedDate(ResultSet rs, int rowNum) throws SQLException {
+    public static Pair<RoomName, LocalDateTime> mapLastDownloadedDate(ResultSet rs, int rowNum) throws SQLException {
         if (rs.getTimestamp("download_timestamp") == null) {
-            return Pair.of(rs.getString("roomname"), null);
+            return Pair.of(RoomName.of(rs.getString("roomname")), null);
         } else {
-            return Pair.of(rs.getString("roomname"), rs.getObject("download_timestamp", LocalDateTime.class));
+            return Pair.of(RoomName.of(rs.getString("roomname")), rs.getObject("download_timestamp", LocalDateTime.class));
         }
     }
 

--- a/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
@@ -16,8 +16,7 @@ public abstract class RowMappers {
 
     public static ChatMessageEntity mapToChatMessageEntity(ResultSet rs, int rowNum) throws SQLException {
 
-        UserEntity user = UserEntity.of(rs.getLong("user_id"),
-                Username.of(rs.getString("username")));
+        UserEntity user = UserEntity.of(Username.of(rs.getString("username")));
 
         String roomName = rs.getString("roomname");
         RoomTypeEnum roomType = getRoomType(roomName);

--- a/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
@@ -98,15 +98,15 @@ public abstract class RowMappers {
         );
     }
 
-    public static Pair<Long, Integer> mapNotDownloadedMessagesCount(ResultSet rs, int rowNum) throws SQLException {
-        return Pair.of(rs.getLong("id"), rs.getInt("not_downloaded_count"));
+    public static Pair<String, Integer> mapNotDownloadedMessagesCount(ResultSet rs, int rowNum) throws SQLException {
+        return Pair.of(rs.getString("roomname"), rs.getInt("not_downloaded_count"));
     }
 
-    public static Pair<Long, LocalDateTime> mapLastDownloadedDate(ResultSet rs, int rowNum) throws SQLException {
+    public static Pair<String, LocalDateTime> mapLastDownloadedDate(ResultSet rs, int rowNum) throws SQLException {
         if (rs.getTimestamp("download_timestamp") == null) {
-            return Pair.of(rs.getLong("id"), null);
+            return Pair.of(rs.getString("roomname"), null);
         } else {
-            return Pair.of(rs.getLong("id"), rs.getObject("download_timestamp", LocalDateTime.class));
+            return Pair.of(rs.getString("roomname"), rs.getObject("download_timestamp", LocalDateTime.class));
         }
     }
 

--- a/src/main/java/com/cgm/infolab/db/repository/queryhelper/UserQueryResult.java
+++ b/src/main/java/com/cgm/infolab/db/repository/queryhelper/UserQueryResult.java
@@ -64,11 +64,10 @@ public record UserQueryResult(
     public String query() {
         return query + "infolab.rooms r %s".formatted(joinKey) +
             "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-            "left join infolab.users u on u.id = s.user_id " +
             (join == null
                 ? ""
                 : join) +
-            "where (u.username = :accessControlUsername or r.visibility='PUBLIC')" +
+            "where (s.username = :accessControlUsername or r.visibility='PUBLIC')" +
             (conditions == null
                 ? ""
                 : " and (%s)".formatted(conditions)) +

--- a/src/main/java/com/cgm/infolab/db/repository/queryhelper/UserQueryResult.java
+++ b/src/main/java/com/cgm/infolab/db/repository/queryhelper/UserQueryResult.java
@@ -63,7 +63,7 @@ public record UserQueryResult(
     @Override
     public String query() {
         return query + "infolab.rooms r %s".formatted(joinKey) +
-            "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+            "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
             (join == null
                 ? ""
                 : join) +

--- a/src/main/java/com/cgm/infolab/model/WebSocketMessageDto.java
+++ b/src/main/java/com/cgm/infolab/model/WebSocketMessageDto.java
@@ -37,7 +37,7 @@ public class WebSocketMessageDto {
     }
 
     public static WebSocketMessageDto ofJoin(ChatMessageDto join) {
-        return new WebSocketMessageDto(WebSocketMessageTypeEnum.DELETE, null, null, null, join);
+        return new WebSocketMessageDto(WebSocketMessageTypeEnum.JOIN, null, null, null, join);
     }
 
     @NonNull
@@ -92,6 +92,7 @@ public class WebSocketMessageDto {
                 ", chat=" + chat +
                 ", edit=" + edit +
                 ", delete=" + delete +
+                ", join=" + join +
                 '}';
     }
 
@@ -100,11 +101,11 @@ public class WebSocketMessageDto {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WebSocketMessageDto that = (WebSocketMessageDto) o;
-        return type == that.type && Objects.equals(chat, that.chat) && Objects.equals(edit, that.edit) && Objects.equals(delete, that.delete);
+        return type == that.type && Objects.equals(chat, that.chat) && Objects.equals(edit, that.edit) && Objects.equals(delete, that.delete) && Objects.equals(join, that.join);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, chat, edit, delete);
+        return Objects.hash(type, chat, edit, delete, join);
     }
 }

--- a/src/main/java/com/cgm/infolab/service/RoomService.java
+++ b/src/main/java/com/cgm/infolab/service/RoomService.java
@@ -70,7 +70,9 @@ public class RoomService {
             });
 
             roomSubscription.setRoomId(room.getId());
+            roomSubscription.setRoomName(roomName);
             roomSubscription.setUserId(user.getId());
+            roomSubscription.setUsername(username);
 
             roomSubscriptionRepository.add(roomSubscription);
         } catch (DuplicateKeyException e) {

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -95,6 +95,12 @@
                 <constraints foreignKeyName="fk_message_id" references="infolab.chatmessages(id)" nullable="false"/>
             </column>
         </createTable>
+        <createIndex schemaName="infolab" tableName="download_dates" indexName="download_dates_username_index">
+            <column name="username"/>
+        </createIndex>
+        <createIndex schemaName="infolab" tableName="download_dates" indexName="download_dates_message_id_index">
+            <column name="message_id"/>
+        </createIndex>
         <addPrimaryKey schemaName="infolab" tableName="download_dates" columnNames="download_timestamp, username, message_id"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -94,9 +94,6 @@
             <column name="download_timestamp" type="timestamp">
                 <constraints nullable="false"/>
             </column>
-            <column name="user_id" type="bigint">
-                <constraints foreignKeyName="fk_download_dates_user_id" references="infolab.users(id)" nullable="false"/>
-            </column>
             <column name="username" type="varchar(50)">
                 <constraints foreignKeyName="fk_download_dates_username" references="infolab.users(username)" nullable="false"/>
             </column>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -5,11 +5,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="setup" author="Luca Piccinelli">
+    <changeSet id="rebuilding all" author="Lorenzo Rinaldi">
         <sql>
             create schema infolab
         </sql>
 
+        <!-- Table Users -->
         <createTable schemaName="infolab" tableName="users">
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="users_pk" />
@@ -17,11 +18,13 @@
             <column name="username" type="varchar(50)" >
                 <constraints unique="true"/>
             </column>
+            <column name="description" type="varchar(500)" />
         </createTable>
         <createIndex schemaName="infolab" tableName="users" indexName="users_index">
             <column name="username" />
         </createIndex>
 
+        <!-- Table Rooms -->
         <createTable schemaName="infolab" tableName="rooms">
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="rooms_pk" />
@@ -29,8 +32,14 @@
             <column name="roomname" type="varchar(255)">
                 <constraints unique="true"/>
             </column>
+            <column name="visibility" type="char(20)"/>
+            <column name="description" type="varchar(500)"/>
         </createTable>
+        <createIndex schemaName="infolab" tableName="rooms" indexName="rooms_index">
+            <column name="roomname"/>
+        </createIndex>
 
+        <!-- Table ChatMessages -->
         <createTable schemaName="infolab" tableName="chatmessages">
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="chatmessages_pk" />
@@ -38,32 +47,55 @@
             <column name="sender_id" type="bigint" >
                 <constraints foreignKeyName="fk_sender_id" references="infolab.users(id)"/>
             </column>
+            <column name="sender_name" type="varchar(50)" >
+                <constraints foreignKeyName="fk_sender_name" references="infolab.users(username)"/>
+            </column>
             <column name="recipient_room_id" type="bigint">
                 <constraints foreignKeyName="fk_recipient_room_id" references="infolab.rooms(id)"/>
+            </column>
+            <column name="recipient_room_name" type="varchar(255)">
+                <constraints foreignKeyName="fk_recipient_room_name" references="infolab.rooms(roomname)"/>
             </column>
             <column name="sent_at" type="timestamp" >
                 <constraints nullable="false" />
             </column>
             <column name="content" type="varchar(5000)" />
+            <column name="status" type="char(20)"/>
         </createTable>
-    </changeSet>
-    
-    <changeSet id="rooms_users_relation" author="Matei Ciofu">
+        <createIndex schemaName="infolab" tableName="chatmessages" indexName="messages_sent_at_index">
+            <column name="sent_at"/>
+        </createIndex>
+        <createIndex schemaName="infolab" tableName="chatmessages" indexName="messages_sender_name_index">
+            <column name="sender_name"/>
+        </createIndex>
+        <createIndex schemaName="infolab" tableName="chatmessages" indexName="messages_recipient_room_name_index">
+            <column name="recipient_room_name"/>
+        </createIndex>
+
+        <!-- Table RoomsSubscriptions -->
         <createTable schemaName="infolab" tableName="rooms_subscriptions">
             <column name="room_id" type="bigint">
-                <constraints foreignKeyName="fk_room_id" references="infolab.rooms(id)" nullable="false"/>
+                <constraints foreignKeyName="fk_rooms_subscriptions_room_id" references="infolab.rooms(id)" nullable="false"/>
+            </column>
+            <column name="roomname" type="varchar(255)">
+                <constraints foreignKeyName="fk_rooms_subscriptions_roomname" references="infolab.rooms(roomname)" nullable="false"/>
             </column>
             <column name="user_id" type="bigint">
                 <constraints foreignKeyName="fk_rooms_subscriptions_user_id" references="infolab.users(id)" nullable="false"/>
             </column>
+            <column name="username" type="varchar(50)">
+                <constraints foreignKeyName="fk_rooms_subscriptions_username" references="infolab.users(username)" nullable="false"/>
+            </column>
         </createTable>
+        <createIndex schemaName="infolab" tableName="rooms_subscriptions" indexName="rooms_subscriptions_roomname_index">
+            <column name="roomname"/>
+        </createIndex>
+        <createIndex schemaName="infolab" tableName="rooms_subscriptions" indexName="rooms_subscriptions_username_index">
+            <column name="username"/>
+        </createIndex>
+        <addPrimaryKey constraintName="rooms_subscriptions_composite_primary_key" schemaName="infolab" tableName="rooms_subscriptions" columnNames="roomname, username"/>
 
-        <addColumn schemaName="infolab" tableName="rooms">
-            <column name="visibility" type="char(20)"/>
-        </addColumn>
-    </changeSet>
-    
-    <changeSet id="last_download_dates_table" author="Lorenzo Rinaldi">
+        <!-- Table DownloadDates -->
         <createTable schemaName="infolab" tableName="download_dates">
             <column name="download_timestamp" type="timestamp">
                 <constraints nullable="false"/>
@@ -71,29 +103,13 @@
             <column name="user_id" type="bigint">
                 <constraints foreignKeyName="fk_download_dates_user_id" references="infolab.users(id)" nullable="false"/>
             </column>
+            <column name="username" type="varchar(50)">
+                <constraints foreignKeyName="fk_download_dates_username" references="infolab.users(username)" nullable="false"/>
+            </column>
             <column name="message_id" type="bigint">
                 <constraints foreignKeyName="fk_message_id" references="infolab.chatmessages(id)" nullable="false"/>
             </column>
         </createTable>
-        
-        <addPrimaryKey schemaName="infolab" tableName="rooms_subscriptions" columnNames="room_id, user_id"/>
-        <addPrimaryKey schemaName="infolab" tableName="download_dates" columnNames="download_timestamp, user_id, message_id"/>
-    </changeSet>
-    <changeSet id="users_description_field" author="Luca Minini">
-        <addColumn schemaName="infolab" tableName="users">
-            <column name="description" type="varchar(500)" />
-        </addColumn>
-    </changeSet>
-
-    <changeSet id="room_description" author="Lorenzo Rinaldi">
-        <addColumn schemaName="infolab" tableName="rooms">
-            <column name="description" type="varchar(500)"/>
-        </addColumn>
-    </changeSet>
-
-    <changeSet id="message_status" author="Lorenzo Rinaldi">
-        <addColumn schemaName="infolab" tableName="chatmessages">
-            <column name="status" type="char(20)"/>
-        </addColumn>
+        <addPrimaryKey schemaName="infolab" tableName="download_dates" columnNames="download_timestamp, username, message_id"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -74,14 +74,8 @@
 
         <!-- Table RoomsSubscriptions -->
         <createTable schemaName="infolab" tableName="rooms_subscriptions">
-            <column name="room_id" type="bigint">
-                <constraints foreignKeyName="fk_rooms_subscriptions_room_id" references="infolab.rooms(id)" nullable="false"/>
-            </column>
             <column name="roomname" type="varchar(255)">
                 <constraints foreignKeyName="fk_rooms_subscriptions_roomname" references="infolab.rooms(roomname)" nullable="false"/>
-            </column>
-            <column name="user_id" type="bigint">
-                <constraints foreignKeyName="fk_rooms_subscriptions_user_id" references="infolab.users(id)" nullable="false"/>
             </column>
             <column name="username" type="varchar(50)">
                 <constraints foreignKeyName="fk_rooms_subscriptions_username" references="infolab.users(username)" nullable="false"/>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -44,9 +44,6 @@
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" primaryKeyName="chatmessages_pk" />
             </column>
-            <column name="sender_id" type="bigint" >
-                <constraints foreignKeyName="fk_sender_id" references="infolab.users(id)"/>
-            </column>
             <column name="sender_name" type="varchar(50)" >
                 <constraints foreignKeyName="fk_sender_name" references="infolab.users(username)"/>
             </column>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -47,9 +47,6 @@
             <column name="sender_name" type="varchar(50)" >
                 <constraints foreignKeyName="fk_sender_name" references="infolab.users(username)"/>
             </column>
-            <column name="recipient_room_id" type="bigint">
-                <constraints foreignKeyName="fk_recipient_room_id" references="infolab.rooms(id)"/>
-            </column>
             <column name="recipient_room_name" type="varchar(255)">
                 <constraints foreignKeyName="fk_recipient_room_name" references="infolab.rooms(roomname)"/>
             </column>

--- a/src/test/java/com/cgm/infolab/LastDownloadDateUpdateTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadDateUpdateTests.java
@@ -48,7 +48,7 @@ public class LastDownloadDateUpdateTests {
             ChatMessageDto.of("Visible only to user1 and user2", users[2].getName().value()),
     };
 
-    public String query = "select * from infolab.download_dates d left join infolab.chatmessages m on m.id = d.message_id where d.user_id = ? and m.content = ?";
+    public String query = "select * from infolab.download_dates d left join infolab.chatmessages m on m.id = d.message_id where d.username = ? and m.content = ?";
 
     @BeforeAll
     void setUp() {
@@ -77,7 +77,7 @@ public class LastDownloadDateUpdateTests {
         List<String> fromDb = jdbcTemplate.query(
                 query,
                 (rs, rowNum) -> rs.getString("content"),
-                users[0].getId(),
+                users[0].getName().value(),
                 generalMessage
         );
 
@@ -88,7 +88,7 @@ public class LastDownloadDateUpdateTests {
         List<String> fromDb2 = jdbcTemplate.query(
                 query,
                 (rs, rowNum) -> rs.getString("content"),
-                users[0].getId(),
+                users[0].getName().value(),
                 "Visible only to user1 and user2"
         );
 
@@ -105,7 +105,7 @@ public class LastDownloadDateUpdateTests {
         Timestamp timestampFirstMessage = jdbcTemplate.query(
                 query,
                 (rs, rowNum) -> rs.getTimestamp("download_timestamp"),
-                users[0].getId(),
+                users[0].getName().value(),
                 generalMessage
         )
         .get(0);
@@ -117,7 +117,7 @@ public class LastDownloadDateUpdateTests {
         List<String> fromDb = jdbcTemplate.query(
                 query,
                 (rs, rowNum) -> rs.getString("content"),
-                users[0].getId(),
+                users[0].getName().value(),
                 generalMessage2
         );
 
@@ -126,7 +126,7 @@ public class LastDownloadDateUpdateTests {
         Timestamp timestampSecondMessage = jdbcTemplate.query(
                         query,
                         (rs, rowNum) -> rs.getTimestamp("download_timestamp"),
-                        users[0].getId(),
+                        users[0].getName().value(),
                         generalMessage2
                 )
                 .get(0);

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -78,11 +78,11 @@ public class LastDownloadedDatesForRoomsTests {
         loggedInUserId = jdbcTemplate.queryForObject("select * from infolab.users where username = 'user0'", (rs, rowNum) -> rs.getLong("id"));
 
         // Adding messages and read dates
-        testDbHelper.insertCustomMessage(0, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME, messageDtos[0].getContent());
-        testDbHelper.insertCustomMessage(1, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
+        testDbHelper.insertCustomMessage(0, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME, messageDtos[0].getContent());
+        testDbHelper.insertCustomMessage(1, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
 
-        testDbHelper.insertCustomMessage(2, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
-        testDbHelper.insertCustomMessage(3, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
+        testDbHelper.insertCustomMessage(2, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
+        testDbHelper.insertCustomMessage(3, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
 
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, users[0].getName().value());
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, users[0].getName().value());
@@ -91,8 +91,8 @@ public class LastDownloadedDatesForRoomsTests {
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, users[0].getName().value());
 
         // Adding the remaining messages
-        testDbHelper.insertCustomMessage(4, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
-        testDbHelper.insertCustomMessage(5, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
+        testDbHelper.insertCustomMessage(4, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
+        testDbHelper.insertCustomMessage(5, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
     }
 
     @Test

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -97,14 +97,14 @@ public class LastDownloadedDatesForRoomsTests {
 
     @Test
     void whenFetchingLastReadDates_fromGeneralAndFromPrivateRoom_theyAreTheExpectedOnes() {
-        Map<String, LocalDateTime> downloadDatesUser0 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName().value(), user0Uuser1RoomName.value()), users[0].getName());
+        Map<RoomName, LocalDateTime> downloadDatesUser0 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName(), user0Uuser1RoomName), users[0].getName());
 
         Assertions.assertEquals(2, downloadDatesUser0.size());
 
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDatesUser0.get(general.getName().value()));
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDatesUser0.get(user0Uuser1RoomName.value()));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDatesUser0.get(general.getName()));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDatesUser0.get(user0Uuser1RoomName));
 
-        Map<String, LocalDateTime> downloadDatesUser1 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName().value(), user0Uuser1RoomName.value()), users[1].getName());
+        Map<RoomName, LocalDateTime> downloadDatesUser1 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName(), user0Uuser1RoomName), users[1].getName());
 
         Assertions.assertEquals(0, downloadDatesUser1.size());
     }

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -78,11 +78,11 @@ public class LastDownloadedDatesForRoomsTests {
         loggedInUserId = jdbcTemplate.queryForObject("select * from infolab.users where username = 'user0'", (rs, rowNum) -> rs.getLong("id"));
 
         // Adding messages and read dates
-        testDbHelper.insertCustomMessage(0, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME, messageDtos[0].getContent());
-        testDbHelper.insertCustomMessage(1, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
+        testDbHelper.insertCustomMessage(0, users[0].getName().value(), general.getName().value(), STARTING_TIME, messageDtos[0].getContent());
+        testDbHelper.insertCustomMessage(1, users[0].getName().value(), general.getName().value(), STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
 
-        testDbHelper.insertCustomMessage(2, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
-        testDbHelper.insertCustomMessage(3, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
+        testDbHelper.insertCustomMessage(2, users[0].getName().value(), user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
+        testDbHelper.insertCustomMessage(3, users[0].getName().value(), user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
 
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, users[0].getName().value());
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, users[0].getName().value());
@@ -91,20 +91,20 @@ public class LastDownloadedDatesForRoomsTests {
         testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, users[0].getName().value());
 
         // Adding the remaining messages
-        testDbHelper.insertCustomMessage(4, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
-        testDbHelper.insertCustomMessage(5, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
+        testDbHelper.insertCustomMessage(4, users[0].getName().value(), general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
+        testDbHelper.insertCustomMessage(5, users[0].getName().value(), general.getName().value(), STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
     }
 
     @Test
     void whenFetchingLastReadDates_fromGeneralAndFromPrivateRoom_theyAreTheExpectedOnes() {
-        Map<Long, LocalDateTime> downloadDatesUser0 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(generalId, user0user1Id), users[0].getName());
+        Map<String, LocalDateTime> downloadDatesUser0 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName().value(), user0Uuser1RoomName.value()), users[0].getName());
 
         Assertions.assertEquals(2, downloadDatesUser0.size());
 
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDatesUser0.get(generalId));
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDatesUser0.get(user0user1Id));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDatesUser0.get(general.getName().value()));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDatesUser0.get(user0Uuser1RoomName.value()));
 
-        Map<Long, LocalDateTime> downloadDatesUser1 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(generalId, user0user1Id), users[1].getName());
+        Map<String, LocalDateTime> downloadDatesUser1 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(general.getName().value(), user0Uuser1RoomName.value()), users[1].getName());
 
         Assertions.assertEquals(0, downloadDatesUser1.size());
     }

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -44,6 +44,7 @@ public class LastDownloadedDatesForRoomsTests {
 
     public Long generalId;
     public Long user0user1Id;
+    public RoomName user0Uuser1RoomName = RoomName.of("user0-user1");
     public Long loggedInUserId;
 
     public ChatMessageDto[] messageDtos =
@@ -77,21 +78,21 @@ public class LastDownloadedDatesForRoomsTests {
         loggedInUserId = jdbcTemplate.queryForObject("select * from infolab.users where username = 'user0'", (rs, rowNum) -> rs.getLong("id"));
 
         // Adding messages and read dates
-        testDbHelper.insertCustomMessage(0, loggedInUserId, generalId, STARTING_TIME, messageDtos[0].getContent());
-        testDbHelper.insertCustomMessage(1, loggedInUserId, generalId, STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
+        testDbHelper.insertCustomMessage(0, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME, messageDtos[0].getContent());
+        testDbHelper.insertCustomMessage(1, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(1), messageDtos[1].getContent());
 
-        testDbHelper.insertCustomMessage(2, loggedInUserId, user0user1Id, STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
-        testDbHelper.insertCustomMessage(3, loggedInUserId, user0user1Id, STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
+        testDbHelper.insertCustomMessage(2, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
+        testDbHelper.insertCustomMessage(3, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
 
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, loggedInUserId);
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, loggedInUserId);
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, loggedInUserId, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, loggedInUserId, users[0].getName().value());
 
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(20), 2, loggedInUserId);
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, loggedInUserId);
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(20), 2, loggedInUserId, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, loggedInUserId, users[0].getName().value());
 
         // Adding the remaining messages
-        testDbHelper.insertCustomMessage(4, loggedInUserId, generalId, STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
-        testDbHelper.insertCustomMessage(5, loggedInUserId, generalId, STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
+        testDbHelper.insertCustomMessage(4, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());
+        testDbHelper.insertCustomMessage(5, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(5), messageDtos[3].getContent());
     }
 
     @Test

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -84,11 +84,11 @@ public class LastDownloadedDatesForRoomsTests {
         testDbHelper.insertCustomMessage(2, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(2), messageDtos[4].getContent());
         testDbHelper.insertCustomMessage(3, loggedInUserId, users[0].getName().value(), user0user1Id, user0Uuser1RoomName.value(), STARTING_TIME.plusSeconds(3), messageDtos[5].getContent());
 
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, loggedInUserId, users[0].getName().value());
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, loggedInUserId, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(10), 0, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(11), 1, users[0].getName().value());
 
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(20), 2, loggedInUserId, users[0].getName().value());
-        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, loggedInUserId, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(20), 2, users[0].getName().value());
+        testDbHelper.insertCustomReadDate(STARTING_TIME.plusSeconds(21), 3, users[0].getName().value());
 
         // Adding the remaining messages
         testDbHelper.insertCustomMessage(4, loggedInUserId, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(4), messageDtos[2].getContent());

--- a/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
+++ b/src/test/java/com/cgm/infolab/LastDownloadedDatesForRoomsTests.java
@@ -97,12 +97,16 @@ public class LastDownloadedDatesForRoomsTests {
 
     @Test
     void whenFetchingLastReadDates_fromGeneralAndFromPrivateRoom_theyAreTheExpectedOnes() {
-        Map<Long, LocalDateTime> downloadDates = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(generalId, user0user1Id));
+        Map<Long, LocalDateTime> downloadDatesUser0 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(generalId, user0user1Id), users[0].getName());
 
-        Assertions.assertEquals(2, downloadDates.size());
+        Assertions.assertEquals(2, downloadDatesUser0.size());
 
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDates.get(generalId));
-        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDates.get(user0user1Id));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(11), downloadDatesUser0.get(generalId));
+        Assertions.assertEquals(STARTING_TIME.plusSeconds(21), downloadDatesUser0.get(user0user1Id));
+
+        Map<Long, LocalDateTime> downloadDatesUser1 = roomRepository.getLastDownloadedDatesGroupedByRoom(List.of(generalId, user0user1Id), users[1].getName());
+
+        Assertions.assertEquals(0, downloadDatesUser1.size());
     }
 
     @Test

--- a/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
+++ b/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
@@ -64,12 +64,8 @@ public class MessagesPaginatedApiTests {
 
         testDbHelper.addPrivateRoomsAndSubscribeUsers(pairs);
 
-        Long generalId = testDbHelper.getRoomId("general");
-
-        Long user0Id = testDbHelper.getUserId("user0");
-
         for (int i = 0; i < messageDtos.length; i++) {
-            testDbHelper.insertCustomMessage(i, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
+            testDbHelper.insertCustomMessage(i, users[0].getName().value(), general.getName().value(), STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
         }
     }
 

--- a/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
+++ b/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
@@ -69,7 +69,7 @@ public class MessagesPaginatedApiTests {
         Long user0Id = testDbHelper.getUserId("user0");
 
         for (int i = 0; i < messageDtos.length; i++) {
-            testDbHelper.insertCustomMessage(i, user0Id, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
+            testDbHelper.insertCustomMessage(i, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
         }
     }
 

--- a/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
+++ b/src/test/java/com/cgm/infolab/MessagesPaginatedApiTests.java
@@ -1,5 +1,6 @@
 package com.cgm.infolab;
 
+import com.cgm.infolab.db.model.RoomEntity;
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
 import com.cgm.infolab.helper.TestApiHelper;
@@ -44,6 +45,8 @@ public class MessagesPaginatedApiTests {
                     UserEntity.of(Username.of("user3"))};
     public ChatMessageDto[] messageDtos = new ChatMessageDto[80];
 
+    public RoomEntity general = RoomEntity.general();
+
     public static final LocalDateTime STARTING_TIME = LocalDateTime.of(2023, 6, 1, 1, 1, 1);
 
     @BeforeAll
@@ -66,7 +69,7 @@ public class MessagesPaginatedApiTests {
         Long user0Id = jdbcTemplate.queryForObject("select * from infolab.users where username = 'user0'", (rs, rowNum) -> rs.getLong("id"));
 
         for (int i = 0; i < messageDtos.length; i++) {
-            testDbHelper.insertCustomMessage(i, user0Id, generalId, STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
+            testDbHelper.insertCustomMessage(i, user0Id, users[0].getName().value(), generalId, general.getName().value(), STARTING_TIME.plusSeconds(i), "%d. Hello general from user0".formatted(i));
         }
     }
 

--- a/src/test/java/com/cgm/infolab/QueryHelperTests.java
+++ b/src/test/java/com/cgm/infolab/QueryHelperTests.java
@@ -23,8 +23,7 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
             "from infolab.rooms r " +
             "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-            "left join infolab.users u on u.id = s.user_id " +
-            "where (u.username = :accessControlUsername or r.visibility='PUBLIC')";
+            "where (s.username = :accessControlUsername or r.visibility='PUBLIC')";
 
         Assertions.assertEquals(expectedQuery, query.query());
     }
@@ -41,8 +40,7 @@ public class QueryHelperTests {
             "from _anotherTable x " +
             "right join infolab.rooms r on r.id = x.banana_id " +
             "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-            "left join infolab.users u on u.id = s.user_id " +
-            "where (u.username = :accessControlUsername or r.visibility='PUBLIC')";
+            "where (s.username = :accessControlUsername or r.visibility='PUBLIC')";
 
         Assertions.assertEquals(expectedQuery, query.query());
     }
@@ -58,8 +56,7 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
             "from infolab.rooms r " +
             "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-            "left join infolab.users u on u.id = s.user_id " +
-            "where (u.username = :accessControlUsername or r.visibility='PUBLIC')" +
+            "where (s.username = :accessControlUsername or r.visibility='PUBLIC')" +
             " and (x=? AND bla='foo')"
             ;
 
@@ -79,8 +76,7 @@ public class QueryHelperTests {
             "from _anotherTable x " +
             "right join infolab.rooms r on r.id = x._anotherTable_id " +
             "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-            "left join infolab.users u on u.id = s.user_id " +
-            "where (u.username = :accessControlUsername or r.visibility='PUBLIC')" +
+            "where (s.username = :accessControlUsername or r.visibility='PUBLIC')" +
             " and (x=? AND bla='foo')"
             ;
 
@@ -98,9 +94,8 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
                 "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-                "left join infolab.users u on u.id = s.user_id " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
-                "where (u.username = :accessControlUsername or r.visibility='PUBLIC')"
+                "where (s.username = :accessControlUsername or r.visibility='PUBLIC')"
                 ;
 
         Assertions.assertEquals(expectedQuery, query.query());
@@ -118,9 +113,8 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
                 "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-                "left join infolab.users u on u.id = s.user_id " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
-                "where (u.username = :accessControlUsername or r.visibility='PUBLIC') " +
+                "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "and (x=? and OwO = 'foo')"
                 ;
 
@@ -138,8 +132,7 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
                 "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-                "left join infolab.users u on u.id = s.user_id " +
-                "where (u.username = :accessControlUsername or r.visibility='PUBLIC') " +
+                "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "order by foo desc limit 69"
                 ;
 
@@ -158,9 +151,8 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
                 "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-                "left join infolab.users u on u.id = s.user_id " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
-                "where (u.username = :accessControlUsername or r.visibility='PUBLIC') " +
+                "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "order by foo desc limit 69"
                 ;
 
@@ -180,9 +172,8 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
                 "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
-                "left join infolab.users u on u.id = s.user_id " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
-                "where (u.username = :accessControlUsername or r.visibility='PUBLIC') " +
+                "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "and (cool = true or t=?) " +
                 "order by foo desc limit 69"
                 ;

--- a/src/test/java/com/cgm/infolab/QueryHelperTests.java
+++ b/src/test/java/com/cgm/infolab/QueryHelperTests.java
@@ -22,7 +22,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
             "from infolab.rooms r " +
-            "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+            "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
             "where (s.username = :accessControlUsername or r.visibility='PUBLIC')";
 
         Assertions.assertEquals(expectedQuery, query.query());
@@ -39,7 +39,7 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
             "from _anotherTable x " +
             "right join infolab.rooms r on r.id = x.banana_id " +
-            "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+            "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
             "where (s.username = :accessControlUsername or r.visibility='PUBLIC')";
 
         Assertions.assertEquals(expectedQuery, query.query());
@@ -55,7 +55,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
             "from infolab.rooms r " +
-            "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+            "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
             "where (s.username = :accessControlUsername or r.visibility='PUBLIC')" +
             " and (x=? AND bla='foo')"
             ;
@@ -75,7 +75,7 @@ public class QueryHelperTests {
         String expectedQuery = "Select * " +
             "from _anotherTable x " +
             "right join infolab.rooms r on r.id = x._anotherTable_id " +
-            "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+            "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
             "where (s.username = :accessControlUsername or r.visibility='PUBLIC')" +
             " and (x=? AND bla='foo')"
             ;
@@ -93,7 +93,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
-                "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+                "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
                 "where (s.username = :accessControlUsername or r.visibility='PUBLIC')"
                 ;
@@ -112,7 +112,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
-                "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+                "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
                 "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "and (x=? and OwO = 'foo')"
@@ -131,7 +131,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
-                "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+                "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
                 "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "order by foo desc limit 69"
                 ;
@@ -150,7 +150,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
-                "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+                "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
                 "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "order by foo desc limit 69"
@@ -171,7 +171,7 @@ public class QueryHelperTests {
 
         String expectedQuery = "Select * " +
                 "from infolab.rooms r " +
-                "left join infolab.rooms_subscriptions s on r.id = s.room_id " +
+                "left join infolab.rooms_subscriptions s on r.roomname = s.roomname " +
                 "left join _another_table x on x._foreign_key_id = r.id " +
                 "where (s.username = :accessControlUsername or r.visibility='PUBLIC') " +
                 "and (cool = true or t=?) " +

--- a/src/test/java/com/cgm/infolab/RoomAndMessagesVisibilityTests.java
+++ b/src/test/java/com/cgm/infolab/RoomAndMessagesVisibilityTests.java
@@ -94,6 +94,11 @@ public class RoomAndMessagesVisibilityTests {
             .sorted(Comparator.comparing(roomEntity -> roomEntity.getName().value()))
             .toList();
 
+        for (RoomEntity r :
+                roomsFromDb) {
+            System.out.println(r.getName().value());
+        }
+
         Assertions.assertEquals(4, roomsFromDb.size());
 
         Assertions.assertEquals(general.getName(), roomsFromDb.get(0).getName());

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
@@ -74,13 +74,9 @@ public class WebSocketDeleteEditPrivateTests {
         long bananaUser1Id = testDbHelper.getRoomId("banana-user1");
         bananaUser1.setId(bananaUser1Id);
 
-        long user1Id = testDbHelper.getUserId("user1");
-        long userBananaId = testDbHelper.getUserId("banana");
-
         testDbHelper.insertCustomMessage(
                 1,
                 user1.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "1 Message in banana-user1");
@@ -88,7 +84,6 @@ public class WebSocketDeleteEditPrivateTests {
         testDbHelper.insertCustomMessage(
                 2,
                 user1.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "2 Message in banana-user1");
@@ -96,7 +91,6 @@ public class WebSocketDeleteEditPrivateTests {
         testDbHelper.insertCustomMessage(
                 3,
                 userBanana.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "3 Message in banana-user1");
@@ -104,21 +98,18 @@ public class WebSocketDeleteEditPrivateTests {
         testDbHelper.insertCustomMessage(
                 4,
                 userBanana.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "4 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 5,
                 user1.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "5 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 6,
                 user1.getName().value(),
-                bananaUser1Id,
                 bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "6 Message in banana-user1");

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
@@ -1,8 +1,8 @@
 package com.cgm.infolab;
 
-import com.cgm.infolab.db.model.ChatMessageEntity;
-import com.cgm.infolab.db.model.UserEntity;
-import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.*;
+import com.cgm.infolab.db.model.enumeration.RoomTypeEnum;
+import com.cgm.infolab.db.model.enumeration.VisibilityEnum;
 import com.cgm.infolab.helper.TestDbHelper;
 import com.cgm.infolab.helper.TestStompHelper;
 import com.cgm.infolab.model.ChatMessageDto;
@@ -59,6 +59,7 @@ public class WebSocketDeleteEditPrivateTests {
 
     UserEntity userBanana = UserEntity.of(Username.of("banana"));
     UserEntity user1 = UserEntity.of(Username.of("user1"));
+    RoomEntity bananaUser1 = RoomEntity.of(RoomName.of("banana-user1"), VisibilityEnum.PRIVATE, RoomTypeEnum.USER2USER);
 
     @BeforeAll
     public void setupAll(){
@@ -71,6 +72,7 @@ public class WebSocketDeleteEditPrivateTests {
         testDbHelper.addPrivateRoomsAndSubscribeUsers(List.of(Pair.of(user1, userBanana)));
 
         long bananaUser1Id = testDbHelper.getRoomId("banana-user1");
+        bananaUser1.setId(bananaUser1Id);
 
         long user1Id = testDbHelper.getUserId("user1");
         long userBananaId = testDbHelper.getUserId("banana");
@@ -78,40 +80,52 @@ public class WebSocketDeleteEditPrivateTests {
         testDbHelper.insertCustomMessage(
                 1,
                 user1Id,
+                user1.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "1 Message in banana-user1");
 
         testDbHelper.insertCustomMessage(
                 2,
                 user1Id,
+                user1.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "2 Message in banana-user1");
 
         testDbHelper.insertCustomMessage(
                 3,
                 userBananaId,
+                userBanana.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "3 Message in banana-user1");
 
         testDbHelper.insertCustomMessage(
                 4,
                 userBananaId,
+                userBanana.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "4 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 5,
                 user1Id,
+                user1.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "5 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 6,
                 user1Id,
+                user1.getName().value(),
                 bananaUser1Id,
+                bananaUser1.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "6 Message in banana-user1");
     }

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPrivateTests.java
@@ -79,7 +79,6 @@ public class WebSocketDeleteEditPrivateTests {
 
         testDbHelper.insertCustomMessage(
                 1,
-                user1Id,
                 user1.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),
@@ -88,7 +87,6 @@ public class WebSocketDeleteEditPrivateTests {
 
         testDbHelper.insertCustomMessage(
                 2,
-                user1Id,
                 user1.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),
@@ -97,7 +95,6 @@ public class WebSocketDeleteEditPrivateTests {
 
         testDbHelper.insertCustomMessage(
                 3,
-                userBananaId,
                 userBanana.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),
@@ -106,7 +103,6 @@ public class WebSocketDeleteEditPrivateTests {
 
         testDbHelper.insertCustomMessage(
                 4,
-                userBananaId,
                 userBanana.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),
@@ -114,7 +110,6 @@ public class WebSocketDeleteEditPrivateTests {
                 "4 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 5,
-                user1Id,
                 user1.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),
@@ -122,7 +117,6 @@ public class WebSocketDeleteEditPrivateTests {
                 "5 Message in banana-user1");
         testDbHelper.insertCustomMessage(
                 6,
-                user1Id,
                 user1.getName().value(),
                 bananaUser1Id,
                 bananaUser1.getName().value(),

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
@@ -81,7 +81,6 @@ public class WebSocketDeleteEditPublicTests {
 
         testDbHelper.insertCustomMessage(
                 1,
-                user1Id,
                 user1.getName().value(),
                 generalId,
                 general.getName().value(),
@@ -90,7 +89,6 @@ public class WebSocketDeleteEditPublicTests {
 
         testDbHelper.insertCustomMessage(
                 2,
-                user1Id,
                 user1.getName().value(),
                 generalId,
                 general.getName().value(),
@@ -99,7 +97,6 @@ public class WebSocketDeleteEditPublicTests {
 
         testDbHelper.insertCustomMessage(
                 3,
-                userBananaId,
                 userBanana.getName().value(),
                 generalId,
                 general.getName().value(),
@@ -108,7 +105,6 @@ public class WebSocketDeleteEditPublicTests {
 
         testDbHelper.insertCustomMessage(
                 4,
-                userBananaId,
                 userBanana.getName().value(),
                 generalId,
                 general.getName().value(),
@@ -116,7 +112,6 @@ public class WebSocketDeleteEditPublicTests {
                 "4 Message in general");
         testDbHelper.insertCustomMessage(
                 5,
-                user1Id,
                 user1.getName().value(),
                 generalId,
                 general.getName().value(),
@@ -124,7 +119,6 @@ public class WebSocketDeleteEditPublicTests {
                 "5 Message in general");
         testDbHelper.insertCustomMessage(
                 6,
-                user1Id,
                 user1.getName().value(),
                 generalId,
                 general.getName().value(),

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
@@ -76,13 +76,9 @@ public class WebSocketDeleteEditPublicTests {
         long generalId = testDbHelper.getRoomId("general");
         general.setId(generalId);
 
-        long user1Id = testDbHelper.getUserId("user1");
-        long userBananaId = testDbHelper.getUserId("banana");
-
         testDbHelper.insertCustomMessage(
                 1,
                 user1.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "1 Message in general");
@@ -90,7 +86,6 @@ public class WebSocketDeleteEditPublicTests {
         testDbHelper.insertCustomMessage(
                 2,
                 user1.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "2 Message in general");
@@ -98,7 +93,6 @@ public class WebSocketDeleteEditPublicTests {
         testDbHelper.insertCustomMessage(
                 3,
                 userBanana.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "3 Message in general");
@@ -106,21 +100,18 @@ public class WebSocketDeleteEditPublicTests {
         testDbHelper.insertCustomMessage(
                 4,
                 userBanana.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "4 Message in general");
         testDbHelper.insertCustomMessage(
                 5,
                 user1.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "5 Message in general");
         testDbHelper.insertCustomMessage(
                 6,
                 user1.getName().value(),
-                generalId,
                 general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "6 Message in general");

--- a/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
+++ b/src/test/java/com/cgm/infolab/WebSocketDeleteEditPublicTests.java
@@ -1,6 +1,7 @@
 package com.cgm.infolab;
 
 import com.cgm.infolab.db.model.ChatMessageEntity;
+import com.cgm.infolab.db.model.RoomEntity;
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
 import com.cgm.infolab.helper.TestDbHelper;
@@ -60,6 +61,8 @@ public class WebSocketDeleteEditPublicTests {
     UserEntity userBanana = UserEntity.of(Username.of("banana"));
     UserEntity user1 = UserEntity.of(Username.of("user1"));
 
+    RoomEntity general = RoomEntity.general();
+
     @BeforeAll
     public void setupAll(){
         testDbHelper.clearDbExceptForGeneral();
@@ -71,6 +74,7 @@ public class WebSocketDeleteEditPublicTests {
         testDbHelper.addPrivateRoomsAndSubscribeUsers(List.of(Pair.of(user1, userBanana)));
 
         long generalId = testDbHelper.getRoomId("general");
+        general.setId(generalId);
 
         long user1Id = testDbHelper.getUserId("user1");
         long userBananaId = testDbHelper.getUserId("banana");
@@ -78,40 +82,52 @@ public class WebSocketDeleteEditPublicTests {
         testDbHelper.insertCustomMessage(
                 1,
                 user1Id,
+                user1.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "1 Message in general");
 
         testDbHelper.insertCustomMessage(
                 2,
                 user1Id,
+                user1.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "2 Message in general");
 
         testDbHelper.insertCustomMessage(
                 3,
                 userBananaId,
+                userBanana.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "3 Message in general");
 
         testDbHelper.insertCustomMessage(
                 4,
                 userBananaId,
+                userBanana.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "4 Message in general");
         testDbHelper.insertCustomMessage(
                 5,
                 user1Id,
+                user1.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "5 Message in general");
         testDbHelper.insertCustomMessage(
                 6,
                 user1Id,
+                user1.getName().value(),
                 generalId,
+                general.getName().value(),
                 LocalDateTime.of(2023, 1, 1, 1, 1, 1),
                 "6 Message in general");
 

--- a/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
@@ -72,9 +72,9 @@ public class TestDbHelper {
         }
     }
 
-    public void insertCustomMessage(long messageId, long senderId, String senderName, long recipientRoomId, String recipientRoomName, LocalDateTime sentAt, String content) {
-        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_id, sender_name, recipient_room_id, recipient_room_name, sent_at, content) values" +
-                "(?, ?, ?, ?, ?, ?, ?)", messageId, senderId, senderName, recipientRoomId, recipientRoomName, sentAt, content);
+    public void insertCustomMessage(long messageId, String senderName, long recipientRoomId, String recipientRoomName, LocalDateTime sentAt, String content) {
+        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_name, recipient_room_id, recipient_room_name, sent_at, content) values" +
+                "(?, ?, ?, ?, ?, ?)", messageId, senderName, recipientRoomId, recipientRoomName, sentAt, content);
     }
 
     public void insertCustomReadDate(LocalDateTime timestamp, long message_id, String username) {
@@ -84,16 +84,16 @@ public class TestDbHelper {
 
     public List<ChatMessageEntity> getAllMessages() {
         return jdbcTemplate
-                .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, m.sender_id, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
+                .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
                         "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.id = m.recipient_room_id " +
-                        "JOIN infolab.users u_mex ON u_mex.id = m.sender_id", RowMappers::mapToChatMessageEntity);
+                        "JOIN infolab.users u_mex ON u_mex.username = m.sender_name", RowMappers::mapToChatMessageEntity);
     }
 
     public <T> List<T> getAllMessages(RowMapper<T> rowMapper) {
         return jdbcTemplate
-                .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, m.sender_id, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
+                .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
                         "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.id = m.recipient_room_id " +
-                        "JOIN infolab.users u_mex ON u_mex.id = m.sender_id", rowMapper);
+                        "JOIN infolab.users u_mex ON u_mex.username = m.sender_name", rowMapper);
     }
 
     public Long getRoomId(String roomName) {

--- a/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
@@ -72,9 +72,9 @@ public class TestDbHelper {
         }
     }
 
-    public void insertCustomMessage(long messageId, String senderName, long recipientRoomId, String recipientRoomName, LocalDateTime sentAt, String content) {
-        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_name, recipient_room_id, recipient_room_name, sent_at, content) values" +
-                "(?, ?, ?, ?, ?, ?)", messageId, senderName, recipientRoomId, recipientRoomName, sentAt, content);
+    public void insertCustomMessage(long messageId, String senderName, String recipientRoomName, LocalDateTime sentAt, String content) {
+        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_name, recipient_room_name, sent_at, content) values" +
+                "(?, ?, ?, ?, ?)", messageId, senderName, recipientRoomName, sentAt, content);
     }
 
     public void insertCustomReadDate(LocalDateTime timestamp, long message_id, String username) {
@@ -85,14 +85,14 @@ public class TestDbHelper {
     public List<ChatMessageEntity> getAllMessages() {
         return jdbcTemplate
                 .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
-                        "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.id = m.recipient_room_id " +
+                        "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.roomname = m.recipient_room_name " +
                         "JOIN infolab.users u_mex ON u_mex.username = m.sender_name", RowMappers::mapToChatMessageEntity);
     }
 
     public <T> List<T> getAllMessages(RowMapper<T> rowMapper) {
         return jdbcTemplate
                 .query("SELECT m.id message_id, u_mex.id user_id, u_mex.username username, r.id room_id, r.roomname, r.visibility, m.sent_at, m.content, m.status " +
-                        "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.id = m.recipient_room_id " +
+                        "FROM infolab.chatmessages m JOIN infolab.rooms r ON r.roomname = m.recipient_room_name " +
                         "JOIN infolab.users u_mex ON u_mex.username = m.sender_name", rowMapper);
     }
 

--- a/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
@@ -77,9 +77,9 @@ public class TestDbHelper {
                 "(?, ?, ?, ?, ?, ?, ?)", messageId, senderId, senderName, recipientRoomId, recipientRoomName, sentAt, content);
     }
 
-    public void insertCustomReadDate(LocalDateTime timestamp, long message_id, long user_id, String username) {
-        jdbcTemplate.update("INSERT INTO infolab.download_dates (download_timestamp, message_id, user_id, username) values" +
-                "(?, ?, ?, ?)", timestamp, message_id, user_id, username);
+    public void insertCustomReadDate(LocalDateTime timestamp, long message_id, String username) {
+        jdbcTemplate.update("INSERT INTO infolab.download_dates (download_timestamp, message_id, username) values" +
+                "(?, ?, ?)", timestamp, message_id, username);
     }
 
     public List<ChatMessageEntity> getAllMessages() {

--- a/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
@@ -72,14 +72,14 @@ public class TestDbHelper {
         }
     }
 
-    public void insertCustomMessage(long messageId, long senderId, long recipientRoomId, LocalDateTime sentAt, String content) {
-        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_id, recipient_room_id, sent_at, content) values" +
-                "(?, ?, ?, ?, ?)", messageId, senderId, recipientRoomId, sentAt, content);
+    public void insertCustomMessage(long messageId, long senderId, String senderName, long recipientRoomId, String recipientRoomName, LocalDateTime sentAt, String content) {
+        jdbcTemplate.update("INSERT INTO infolab.chatmessages (id, sender_id, sender_name, recipient_room_id, recipient_room_name, sent_at, content) values" +
+                "(?, ?, ?, ?, ?, ?, ?)", messageId, senderId, senderName, recipientRoomId, recipientRoomName, sentAt, content);
     }
 
-    public void insertCustomReadDate(LocalDateTime timestamp, long message_id, long user_id) {
-        jdbcTemplate.update("INSERT INTO infolab.download_dates (download_timestamp, message_id, user_id) values" +
-                "(?, ?, ?)", timestamp, message_id, user_id);
+    public void insertCustomReadDate(LocalDateTime timestamp, long message_id, long user_id, String username) {
+        jdbcTemplate.update("INSERT INTO infolab.download_dates (download_timestamp, message_id, user_id, username) values" +
+                "(?, ?, ?, ?)", timestamp, message_id, user_id, username);
     }
 
     public List<ChatMessageEntity> getAllMessages() {


### PR DESCRIPTION
Aggiunti sia username che roomname come chiavi esterne.
Username è utilizzato in molti casi, mentre roomname non è mai utilizzato. Questo perché nel controllo dell'iscrizione alla room bisogna sempre utilizzare la tabella rooms per non perdersi le room pubbliche.
Quando la query sarà divisa in modo da prendere con una parte le room private per poi fare l'union con le room pubbliche la parte delle room private potrà essere semplificata ulteriormente partendo dalla tabella delle iscrizioni alle room. 
Questo però solo in alcuni casi: molte query ritornano dati sulla room oltre all'id e al nome. In quei casi è necessario utilizzare anche la tabella rooms.

Ho anche aggiunto diversi indici, soprattutto sulle nuove chiavi esterne, anche se di solito vengono utilizzati gli id e non i nomi per le join.
Devo aggiungere indici ANCHE per gli id oppure aggiungerli agli id e toglierli dai name?
Oppure è più comodo se utilizzo direttamente i name per fare tutte le join invece degli id? (non l'ho fatto perché pensavo che potesse creare problemi di performance per via del fatto che sono stringhe)