### PR TITLE
Fe/fix formatting buttons

### DIFF
--- a/src/frontend/components/tooltip.js
+++ b/src/frontend/components/tooltip.js
@@ -96,6 +96,14 @@ export class Tooltip extends BaseComponent {
     this.offset = 4;
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    // Setup target if needed
+    this.target ??= this.previousElementSibling;
+    // Ensure hidden at start
+    this.finishHide();
+  }
+
   // Target for which to show tooltip
   _target = null;
   get target() {

--- a/src/frontend/cypress/e2e/editor.cy.js
+++ b/src/frontend/cypress/e2e/editor.cy.js
@@ -70,7 +70,7 @@ describe("Editor spec", () => {
     cy.getEditor().invoke("text").should("be.equal", "😀");
   });
 
-  it("Editor formatting buttons works", () => {
+  it("Editor formatting buttons work", () => {
     cy.getLitElement(buttonIconPath)
       .find(".icon-button")
       .eq(1)
@@ -86,6 +86,30 @@ describe("Editor spec", () => {
     cy.getEditor().type("bold");
 
     cy.getEditor().find("b").should("exist");
+  });
+
+  it("Editor formatting buttons work with highlighted text", () => {
+    cy.getLitElement(buttonIconPath)
+      .find(".icon-button")
+      .eq(1)
+      .click({ force: true });
+
+    cy.getEditor().click({ force: true });
+
+    cy.getEditor().type("Italic test");
+
+    cy.getEditor().realPress(["Shift", "ArrowLeft", "ArrowLeft", "ArrowLeft"]); // This should highlight: est
+
+    cy.getLitElement(
+      "il-app,il-chat,il-input-controls,il-insertion-bar,il-editor-formatting-buttons,il-button-icon"
+    )
+      .find(".icon-button")
+      .eq(1)
+      .click({ force: true });
+
+    cy.getEditor().find("i").should("exist");
+
+    cy.getEditor().find("i").should("have.text", "est");
   });
 });
 

--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -218,7 +218,7 @@ export class Chat extends BaseComponent {
               @il:conversation-changed=${(event) => {
                 this.setActiveChat(event);
                 this.insertStoredTextInEditor();
-                this.focusOnEditor(event);
+                this.focusEditorAndMoveCaretToEnd(event);
                 this.firstNotReadMessage = null;
               }}
               @il:conversation-is-going-to-change=${this
@@ -273,7 +273,7 @@ export class Chat extends BaseComponent {
                             @il:conversation-changed=${(event) => {
                               this.forwardMessage(event);
                               this.insertStoredTextInEditor();
-                              this.focusOnEditor(event);
+                              this.focusEditorAndMoveCaretToEnd(event);
                             }}
                             @il:conversation-is-going-to-change=${this
                               .ifIsEditingExitEditMode}
@@ -497,8 +497,8 @@ export class Chat extends BaseComponent {
     }
   }
 
-  focusOnEditor() {
-    this.inputControlsRef.value?.focusEditor();
+  focusEditorAndMoveCaretToEnd() {
+    this.inputControlsRef.value?.focusEditorAndMoveCaretToEnd();
   }
 
   insertStoredTextInEditor() {
@@ -532,7 +532,7 @@ export class Chat extends BaseComponent {
         ...e.detail.conversation,
       });
 
-      this.inputControlsRef?.value?.focusEditor();
+      this.focusEditorAndMoveCaretToEnd();
     }
   }
 
@@ -595,7 +595,7 @@ export class Chat extends BaseComponent {
         });
       }
 
-      this.inputControlsRef?.value?.focusEditor();
+      this.focusEditorAndMoveCaretToEnd();
     } else {
       this.fetchMessagesLast(e);
     }

--- a/src/frontend/pages/chat/input/editor/editor-formatting-buttons.js
+++ b/src/frontend/pages/chat/input/editor/editor-formatting-buttons.js
@@ -63,8 +63,16 @@ export class EditorFormattingButtons extends LitElement {
   }
 
   formatText(command) {
-    document.execCommand(command, false);
-    this.editor.value.focusEditor();
+    this.dispatchEvent(
+      new CustomEvent("il:text-formatted", {
+        detail: {
+          command: command,
+        },
+      })
+    );
+
+    // document.execCommand(command, false);
+    // this.editor.value.focusEditor();
   }
 }
 customElements.define("il-editor-formatting-buttons", EditorFormattingButtons);

--- a/src/frontend/pages/chat/input/editor/editor.js
+++ b/src/frontend/pages/chat/input/editor/editor.js
@@ -114,14 +114,18 @@ export class Editor extends BaseComponent {
     this.isKeyDown = false;
   }
 
-  focusEditor() {
-    this.editorRef.value?.focus();
+  focusEditorAndMoveCaretToEnd() {
+    this.focusEditor();
     let selection = window.getSelection();
     let range = document.createRange();
     range.selectNodeContents(this.editorRef.value);
     range.collapse(false);
     selection.removeAllRanges();
     selection.addRange(range);
+  }
+
+  focusEditor() {
+    this.editorRef.value?.focus();
   }
 
   insertStoredTextInEditor() {
@@ -176,6 +180,10 @@ export class Editor extends BaseComponent {
 
   setEditorText(text) {
     this.editorRef.value.innerHTML = text;
+  }
+
+  setIsKeyDown(value) {
+    this.isKeyDown = value;
   }
 }
 

--- a/src/frontend/pages/chat/input/editor/editor.js
+++ b/src/frontend/pages/chat/input/editor/editor.js
@@ -25,14 +25,8 @@ export class Editor extends BaseComponent {
   }
 
   static styles = css`
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-      ${ThemeColorService.getThemeVariables()};
-    }
-
     #editor {
+      ${ThemeColorService.getThemeVariables()};
       color: ${ThemeCSSVariables.text};
       background-color: ${ThemeCSSVariables.editorInputBg};
       flex: 1;

--- a/src/frontend/pages/chat/input/editor/editor.js
+++ b/src/frontend/pages/chat/input/editor/editor.js
@@ -134,7 +134,7 @@ export class Editor extends BaseComponent {
     const textFromStorage = localStorage.getItem(`message:${cookie.lastChat}`);
     const text = textFromStorage ? textFromStorage : "";
 
-    this.editorRef.value.textContent = text;
+    this.editorRef.value.innerHTML = text;
 
     this.textChanged();
   }

--- a/src/frontend/pages/chat/input/input-controls.js
+++ b/src/frontend/pages/chat/input/input-controls.js
@@ -249,7 +249,6 @@ export class InputControls extends BaseComponent {
   }
 
   handleFormatText(e) {
-    console.log(e);
     this.allowInsertionInEditor();
     document.execCommand(e.detail.command, false);
     this.focusEditor();

--- a/src/frontend/pages/chat/input/input-controls.js
+++ b/src/frontend/pages/chat/input/input-controls.js
@@ -115,6 +115,7 @@ export class InputControls extends BaseComponent {
               @il:edit-confirmed=${this.confirmEdit}
               @il:edit-canceled=${this.handleEditCanceled}
               @il:editor-mode-changed=${this.changeEditorMode}
+              @il:text-formatted=${this.handleFormatText}
               .editor=${this.editorRef}
               .isEditing=${this.isEditing}
             >
@@ -139,7 +140,11 @@ export class InputControls extends BaseComponent {
   }
 
   focusEditor() {
-    this.editorRef.value.focusEditor();
+    this.editorRef.value?.focusEditor();
+  }
+
+  focusEditorAndMoveCaretToEnd() {
+    this.editorRef.value?.focusEditorAndMoveCaretToEnd();
   }
 
   insertStoredTextInEditor() {
@@ -209,7 +214,7 @@ export class InputControls extends BaseComponent {
     this.isEditing = true;
     this.messageBeingEdited = detail.message;
     this.indexBeingEdited = detail.messageIndex;
-    this.focusEditor();
+    this.focusEditorAndMoveCaretToEnd();
   }
 
   changeEditorMode(event) {
@@ -232,7 +237,7 @@ export class InputControls extends BaseComponent {
     this.messageBeingEdited = {};
     this.indexBeingEdited = undefined;
     this.clearMessage();
-    this.focusEditor();
+    this.focusEditorAndMoveCaretToEnd();
   }
 
   handleEditCanceled() {
@@ -240,13 +245,29 @@ export class InputControls extends BaseComponent {
     this.messageBeingEdited = {};
     this.indexBeingEdited = undefined;
     this.clearMessage();
+    this.focusEditorAndMoveCaretToEnd();
+  }
+
+  handleFormatText(e) {
+    console.log(e);
+    this.allowInsertionInEditor();
+    document.execCommand(e.detail.command, false);
     this.focusEditor();
+    this.blockInsertionInEditor();
   }
 
   ifIsEditingExitEditMode() {
     if (this.isEditing) {
       this.handleEditCanceled();
     }
+  }
+
+  allowInsertionInEditor() {
+    this.editorRef.value?.setIsKeyDown(true);
+  }
+
+  blockInsertionInEditor() {
+    this.editorRef.value?.setIsKeyDown(false);
   }
 }
 

--- a/src/frontend/pages/chat/input/insertion-bar.js
+++ b/src/frontend/pages/chat/input/insertion-bar.js
@@ -61,6 +61,11 @@ export class InsertionBar extends LitElement {
             this.areFormattingButtonsOpen,
             () =>
               html`<il-editor-formatting-buttons
+                @il:text-formatted=${(e) => {
+                  this.dispatchEvent(
+                    new CustomEvent(e.type, { detail: e.detail })
+                  );
+                }}
                 .editor=${this.editor}
               ></il-editor-formatting-buttons>`
           )}

--- a/src/frontend/pages/chat/sidebar/conversation/conversation-list.js
+++ b/src/frontend/pages/chat/sidebar/conversation/conversation-list.js
@@ -92,21 +92,17 @@ class ConversationList extends BaseComponent {
     ) {
       let usernames = new Set();
 
-      if (changedProperties.has("conversationList")) {
-        this.conversationList.forEach((conversation) => {
-          if (conversation.roomType === "USER2USER") {
-            usernames.add(conversation.otherParticipants[0].name);
-          }
-        });
-      }
+      this.conversationList.forEach((conversation) => {
+        if (conversation.roomType === "USER2USER") {
+          usernames.add(conversation.otherParticipants[0].name);
+        }
+      });
 
-      if (changedProperties.has("newConversationList")) {
-        this.newConversationList.forEach((conversation) => {
-          if (conversation.roomType === "USER2USER") {
-            usernames.add(conversation.otherParticipants[0].name);
-          }
-        });
-      }
+      this.newConversationList.forEach((conversation) => {
+        if (conversation.roomType === "USER2USER") {
+          usernames.add(conversation.otherParticipants[0].name);
+        }
+      });
 
       usernames.add(this.cookie.username);
 


### PR DESCRIPTION
Ho fixato per la maggior parte i formatting buttons. Ora il bold, italic, underlined, strike, undo e redo funzionano. Anche quando i messaggi vengono salvati nel local storage e ripristinati da lì la formattazione resta.

Non riesco assolutamente a capire perché non inserisce le liste ordered o unordered. Ho provato proprio a prendere una lista e a settarla dai dev tools come lista al suo interno, ma non si vede. Comunque i bottoni settano l'innerHTML correttamente.

Se potesse essere utile l'editor smette di funzionare dalla commit 7bd8e0baf1b42ba3a2f2d6f25c7ffb85eb50140d ma fa così perché non inserisce nulla.

Ho fixato anche i tooltip che non venivano mostrati.