### PR TITLE
fe/fix-header-user-status

### DIFF
--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -961,6 +961,11 @@ export class Chat extends BaseComponent {
 
       this.messagesListRef.value?.getAllNeededUsers();
       this.conversationListRef.value?.getAllNeededUsers();
+
+      if (joinMessage.sender === this.headerRef.value?.getOtherUser().name) {
+        let user = (await UsersService.getUsers([joinMessage.sender]))[0];
+        this.headerRef.value?.setOtherUser(user);
+      }
     }
   }
 
@@ -975,6 +980,11 @@ export class Chat extends BaseComponent {
 
       this.messagesListRef.value?.getAllNeededUsers();
       this.conversationListRef.value?.getAllNeededUsers();
+
+      if (quitMessage.sender === this.headerRef.value?.getOtherUser().name) {
+        let user = (await UsersService.getUsers([quitMessage.sender]))[0];
+        this.headerRef.value?.setOtherUser(user);
+      }
     }
   }
 

--- a/src/frontend/pages/chat/header/chat-header.js
+++ b/src/frontend/pages/chat/header/chat-header.js
@@ -179,6 +179,10 @@ export class ChatHeader extends BaseComponent {
   setOtherUser(user) {
     this.otherUser = user;
   }
+
+  getOtherUser() {
+    return this.otherUser;
+  }
 }
 
 customElements.define("il-chat-header", ChatHeader);


### PR DESCRIPTION
Fixed bug where user status was not updated in header along with conversation list.

Non sono riuscito a sistemare il problema inerente il test che fallisce per lo status code. Questo perché non ho trovato modo di catchare l'eccezione. Anche se la si catcha nella console rimane lo stesso quella che dice che la chiamata all'api è fallita.

Il test comunque va bene la maggior parte delle volte.

Per aggirare il problema, anche se non è proprio giusto, posso togliere dal backend la parte che lancia lo status code e mettere semplicemente che ritorna un risultato vuoto.