### PR TITLE
Be/theme save

### DIFF
--- a/src/frontend/components/circular-progress-bar.js
+++ b/src/frontend/components/circular-progress-bar.js
@@ -1,8 +1,9 @@
-import { html, css, LitElement } from "lit";
+import { html, css } from "lit";
 import { ThemeColorService } from "../services/theme-color-service";
 import { ThemeCSSVariables } from "../enums/theme-css-variables";
+import { BaseComponent } from "./base-component";
 
-class CircularProgressBar extends LitElement {
+class CircularProgressBar extends BaseComponent {
   static styles = css`
     .circular-progress {
       ${ThemeColorService.getThemeVariables()};

--- a/src/frontend/models/user-dto.js
+++ b/src/frontend/models/user-dto.js
@@ -4,6 +4,7 @@ export class UserDto {
   description = "";
   status = "";
   avatarLink = "";
+  theme = "";
 
   constructor(obj) {
     this.id = obj.id !== undefined ? obj.id : 0;
@@ -11,5 +12,6 @@ export class UserDto {
     this.description = obj.description !== undefined ? obj.description : "";
     this.status = obj.status !== undefined ? obj.status : "";
     this.avatarLink = obj.avatarLink !== undefined ? obj.avatarLink : "";
+    this.theme = obj.theme !== undefined ? obj.theme : "";
   }
 }

--- a/src/frontend/pages/chat/chat.js
+++ b/src/frontend/pages/chat/chat.js
@@ -99,6 +99,10 @@ export class Chat extends BaseComponent {
     await UsersService.getLoggedUser();
     this.canFetchLoggedUser = true;
 
+    if (await ThemeColorService.initService()) {
+      location.reload();
+    }
+
     window.addEventListener("beforeunload", () => {
       if (this.stompClient) {
         const quitMessage = new WebSocketMessageDto({

--- a/src/frontend/pages/chat/header/profile-settings.js
+++ b/src/frontend/pages/chat/header/profile-settings.js
@@ -15,7 +15,7 @@ import "../../../components/input-with-icon";
 import "./theme-switcher";
 
 import { BaseComponent } from "../../../components/base-component";
-import { CommandsService } from "../../../services/commands-service";
+import { UserProfileService } from "../../../services/user-profile-service";
 
 const maxLength = 30;
 
@@ -299,7 +299,7 @@ export class profileSettings extends BaseComponent {
     }
 
     if (this.userDescription !== this.currentUserDescription) {
-      await CommandsService.setUserDescription(this.userDescription);
+      await UserProfileService.setUserDescription(this.userDescription);
       this.dispatchEvent(
         new CustomEvent("il:new-description-set", {
           detail: {

--- a/src/frontend/pages/chat/header/profile-settings.js
+++ b/src/frontend/pages/chat/header/profile-settings.js
@@ -315,10 +315,16 @@ export class profileSettings extends BaseComponent {
     }
 
     // confirming theme
+    await UserProfileService.setUserTheme(
+      ThemeColorService.getCurrentThemeName()
+    );
     this.themeSwitcherRef.value?.setIsThemesSelectionOpened(false);
     this.themeSwitcherRef.value?.setInitialTheme(
       ThemeColorService.getCurrentThemeName()
     );
+    UsersService.updateLoggedUserInSessionStorage({
+      theme: ThemeColorService.getCurrentThemeName().toUpperCase(),
+    });
 
     this.closeMenu();
   }

--- a/src/frontend/services/commands-service.js
+++ b/src/frontend/services/commands-service.js
@@ -12,10 +12,4 @@ export class CommandsService {
       `/api/commands/readall?roomName=${cookie.lastChat}`
     );
   }
-
-  static async setUserDescription(newDescription) {
-    await HttpService.httpPost(
-      `/api/commands/changedesc?newDesc=${newDescription}`
-    );
-  }
 }

--- a/src/frontend/services/theme-color-service.js
+++ b/src/frontend/services/theme-color-service.js
@@ -4,6 +4,8 @@ import { lightTheme } from "../enums/themes/lightTheme";
 import { darkTheme } from "../enums/themes/darkTheme";
 import { ThemeCSSVariables } from "../enums/theme-css-variables";
 
+import { UsersService } from "./users-service";
+
 export class ThemeColorService {
   static changeThemeEvent = new CustomEvent("change-theme");
 
@@ -12,12 +14,33 @@ export class ThemeColorService {
     dark: darkTheme,
   };
 
+  static async initService() {
+    const themeFromDb = (
+      await UsersService.getLoggedUser()
+    ).theme.toLowerCase();
+
+    if (localStorage.getItem("theme") !== themeFromDb) {
+      let isStorageEmptyAndThemeFromDbLight =
+        !localStorage.getItem("theme") && themeFromDb === "light";
+
+      ThemeColorService.setCurrentThemeName(themeFromDb);
+
+      if (isStorageEmptyAndThemeFromDbLight) {
+        return false;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
   static getCurrentThemeName() {
-    return sessionStorage.getItem("theme") ?? "light";
+    return localStorage.getItem("theme") ?? "light";
   }
 
   static setCurrentThemeName(value) {
-    sessionStorage.setItem("theme", value);
+    localStorage.setItem("theme", value);
   }
 
   static getCurrentTheme() {

--- a/src/frontend/services/user-profile-service.js
+++ b/src/frontend/services/user-profile-service.js
@@ -6,4 +6,10 @@ export class UserProfileService {
       `/api/profile/changedesc?newDesc=${newDescription}`
     );
   }
+
+  static async setUserTheme(newTheme) {
+    await HttpService.httpPost(
+      `/api/profile/changetheme?newTheme=${newTheme.toUpperCase()}`
+    );
+  }
 }

--- a/src/frontend/services/user-profile-service.js
+++ b/src/frontend/services/user-profile-service.js
@@ -1,0 +1,9 @@
+import { HttpService } from "./http-service";
+
+export class UserProfileService {
+  static async setUserDescription(newDescription) {
+    await HttpService.httpPost(
+      `/api/profile/changedesc?newDesc=${newDescription}`
+    );
+  }
+}

--- a/src/frontend/services/users-service.js
+++ b/src/frontend/services/users-service.js
@@ -51,8 +51,6 @@ export class UsersService {
   }
 
   static async getLoggedUser() {
-    let cookie = CookieService.getCookie();
-
     let loggedUser;
 
     const sessionUser = sessionStorage.getItem(loggedUserKey);

--- a/src/frontend/services/users-service.js
+++ b/src/frontend/services/users-service.js
@@ -61,15 +61,19 @@ export class UsersService {
       loggedUser = JSON.parse(sessionUser);
     } else {
       try {
-        loggedUser = await UsersService.getUsersByUsernames([cookie.username]);
+        loggedUser = (await HttpService.httpGet("/api/users/loggeduser")).data;
       } catch (error) {
         console.error(error);
       }
 
-      if (loggedUser.length !== 0) {
-        loggedUser = loggedUser[0];
-        sessionStorage.setItem(loggedUserKey, JSON.stringify(loggedUser));
-      }
+      // #region Mock data
+      // TODO: remove this region when data comes from BE
+      loggedUser.avatarLink = "";
+      // #endregion
+
+      loggedUser = new UserDto(loggedUser);
+
+      sessionStorage.setItem(loggedUserKey, JSON.stringify(loggedUser));
     }
 
     return loggedUser;

--- a/src/main/java/com/cgm/infolab/controller/FromEntitiesToDtosMapper.java
+++ b/src/main/java/com/cgm/infolab/controller/FromEntitiesToDtosMapper.java
@@ -78,6 +78,16 @@ public abstract class FromEntitiesToDtosMapper {
         return UserDto.of(userEntity.getName().value(), userEntity.getId(), userEntity.getDescription(), userEntity.getStatus().toString());
     }
 
+    public static UserDto fromEntityToDtoComplete(UserEntity userEntity) {
+        return UserDto.of(
+                userEntity.getName().value(),
+                userEntity.getId(),
+                userEntity.getDescription(),
+                userEntity.getStatus().toString(),
+                userEntity.getTheme().toString()
+        );
+    }
+
     public static BasicJsonDto<RoomDto> fromEntityToDto(String prev, String next, List<RoomEntity> roomEntities, String principalName) {
         PaginationLinksDto linksDto = PaginationLinksDto.of(prev, next);
 

--- a/src/main/java/com/cgm/infolab/controller/api/CommandsApiController.java
+++ b/src/main/java/com/cgm/infolab/controller/api/CommandsApiController.java
@@ -17,13 +17,9 @@ import java.util.List;
 public class CommandsApiController {
 
     private final ChatService chatService;
-    private final UserService userService;
-    private final ApiHelper apiHelper;
 
-    public CommandsApiController(ChatService chatService, UserService userService, ApiHelper apiHelper) {
+    public CommandsApiController(ChatService chatService) {
         this.chatService = chatService;
-        this.userService = userService;
-        this.apiHelper = apiHelper;
     }
 
     @PostMapping(value = "/api/commands/lastread", consumes = {"application/json"})
@@ -34,14 +30,5 @@ public class CommandsApiController {
     @PostMapping("/api/commands/readall")
     public void postReadAll(@RequestParam String roomName, Principal principal) {
         chatService.updateReadTimestamp(Username.of(principal.getName()), RoomName.of(roomName));
-    }
-
-    @PostMapping("/api/commands/changedesc")
-    public void postNewUserDescription(@RequestParam String newDesc, Principal principal) {
-        if (newDesc == null || newDesc.isEmpty()) {
-            apiHelper.throwBadRequestStatus("You cannot set an empty description.");
-        }
-
-        userService.updateUserDescription(Username.of(principal.getName()), newDesc);
     }
 }

--- a/src/main/java/com/cgm/infolab/controller/api/ProfileApiController.java
+++ b/src/main/java/com/cgm/infolab/controller/api/ProfileApiController.java
@@ -1,0 +1,30 @@
+package com.cgm.infolab.controller.api;
+
+import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.service.UserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+public class ProfileApiController {
+
+    private final ApiHelper apiHelper;
+    private final UserService userService;
+
+    public ProfileApiController(ApiHelper apiHelper, UserService userService) {
+        this.apiHelper = apiHelper;
+        this.userService = userService;
+    }
+
+    @PostMapping("/api/profile/changedesc")
+    public void postNewUserDescription(@RequestParam String newDesc, Principal principal) {
+        if (newDesc == null || newDesc.isEmpty()) {
+            apiHelper.throwBadRequestStatus("You cannot set an empty description.");
+        }
+
+        userService.updateUserDescription(Username.of(principal.getName()), newDesc);
+    }
+}

--- a/src/main/java/com/cgm/infolab/controller/api/ProfileApiController.java
+++ b/src/main/java/com/cgm/infolab/controller/api/ProfileApiController.java
@@ -1,6 +1,7 @@
 package com.cgm.infolab.controller.api;
 
 import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.service.UserService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,5 +27,17 @@ public class ProfileApiController {
         }
 
         userService.updateUserDescription(Username.of(principal.getName()), newDesc);
+    }
+
+    @PostMapping("/api/profile/changetheme")
+    public void postThemeChange(@RequestParam String newTheme, Principal principal) {
+        ThemeEnum themeEnum = null;
+        try {
+            themeEnum = ThemeEnum.valueOf(newTheme);
+        } catch (IllegalArgumentException e) {
+            apiHelper.throwBadRequestStatus("The new theme specified is not valid.");
+        }
+
+        userService.updateUserTheme(Username.of(principal.getName()), themeEnum);
     }
 }

--- a/src/main/java/com/cgm/infolab/controller/api/UserApiController.java
+++ b/src/main/java/com/cgm/infolab/controller/api/UserApiController.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,5 +44,20 @@ public class UserApiController {
             log.info("Non sono stati trovati users");
         }
         return UserDtos;
+    }
+
+    @GetMapping("/api/users/loggeduser")
+    public UserDto getLoggedUser(Principal principal) {
+
+        UserDto userDto = UserDto.empty();
+        List<UserEntity> userEntities = userService.getUsersByUsernames(List.of(Username.of(principal.getName())));
+
+        if (!userEntities.isEmpty()) {
+            userDto = FromEntitiesToDtosMapper.fromEntityToDtoComplete(userEntities.get(0));
+        } else {
+            log.info("Non è stato trovato nessuno user");
+        }
+
+        return userDto;
     }
 }

--- a/src/main/java/com/cgm/infolab/db/model/UserEntity.java
+++ b/src/main/java/com/cgm/infolab/db/model/UserEntity.java
@@ -1,6 +1,7 @@
 package com.cgm.infolab.db.model;
 
 import com.cgm.infolab.db.ID;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 
 import java.util.Objects;
@@ -10,39 +11,42 @@ public class UserEntity {
     private Username name;
     private String description;
     private UserStatusEnum status;
+    private ThemeEnum theme;
 
-//    public UserEntity() {
-//    }
-
-    private UserEntity(long id, Username name, String description, UserStatusEnum status) {
+    private UserEntity(long id, Username name, String description, UserStatusEnum status, ThemeEnum theme) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.status = status;
+        this.theme = theme;
     }
 
     public static UserEntity of(Username name) {
-        return new UserEntity(ID.None, name, "", UserStatusEnum.OFFLINE);
+        return new UserEntity(ID.None, name, "", UserStatusEnum.OFFLINE, ThemeEnum.LIGHT);
     }
 
     public static UserEntity of(Username name, String description) {
-        return new UserEntity(ID.None, name, description, UserStatusEnum.OFFLINE);
+        return new UserEntity(ID.None, name, description, UserStatusEnum.OFFLINE, ThemeEnum.LIGHT);
     }
 
     public static UserEntity of(Username name, String description, UserStatusEnum status) {
-        return new UserEntity(ID.None, name, description, status);
+        return new UserEntity(ID.None, name, description, status, ThemeEnum.LIGHT);
     }
 
     public static UserEntity of(long id, Username name, String description) {
-        return new UserEntity(id, name, description, UserStatusEnum.OFFLINE);
+        return new UserEntity(id, name, description, UserStatusEnum.OFFLINE, ThemeEnum.LIGHT);
     }
 
     public static UserEntity of(long id, Username name, String description, UserStatusEnum status) {
-        return new UserEntity(id, name, description, status);
+        return new UserEntity(id, name, description, status, ThemeEnum.LIGHT);
+    }
+
+    public static UserEntity of(long id, Username name, String description, UserStatusEnum status, ThemeEnum theme) {
+        return new UserEntity(id, name, description, status, theme);
     }
 
     public static UserEntity empty() {
-        return new UserEntity(ID.None, Username.empty(), "", UserStatusEnum.OFFLINE);
+        return new UserEntity(ID.None, Username.empty(), "", UserStatusEnum.OFFLINE, ThemeEnum.LIGHT);
     }
 
     public long getId() {
@@ -77,16 +81,35 @@ public class UserEntity {
         this.status = status;
     }
 
+    public ThemeEnum getTheme() {
+        return theme;
+    }
+
+    public void setTheme(ThemeEnum theme) {
+        this.theme = theme;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        UserEntity user = (UserEntity) o;
-        return id == user.id && Objects.equals(name, user.name) && Objects.equals(description, user.description);
+        UserEntity that = (UserEntity) o;
+        return id == that.id && Objects.equals(name, that.name) && Objects.equals(description, that.description) && status == that.status && theme == that.theme;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description);
+        return Objects.hash(id, name, description, status, theme);
+    }
+
+    @Override
+    public String toString() {
+        return "UserEntity{" +
+                "id=" + id +
+                ", name=" + name +
+                ", description='" + description + '\'' +
+                ", status=" + status +
+                ", theme=" + theme +
+                '}';
     }
 }

--- a/src/main/java/com/cgm/infolab/db/model/enumeration/ThemeEnum.java
+++ b/src/main/java/com/cgm/infolab/db/model/enumeration/ThemeEnum.java
@@ -1,0 +1,5 @@
+package com.cgm.infolab.db.model.enumeration;
+
+public enum ThemeEnum {
+    DARK, LIGHT
+}

--- a/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
+++ b/src/main/java/com/cgm/infolab/db/repository/RowMappers.java
@@ -137,7 +137,8 @@ public class RowMappers {
                 rs.getLong("id"),
                 Username.of(usernameString),
                 description,
-                UserStatusEnum.valueOf(rs.getString("user_status").trim())
+                UserStatusEnum.valueOf(rs.getString("user_status").trim()),
+                ThemeEnum.valueOf(rs.getString("theme").trim())
         );
     }
 

--- a/src/main/java/com/cgm/infolab/db/repository/UserRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.cgm.infolab.db.repository;
 
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.db.repository.queryhelper.QueryHelper;
 import com.cgm.infolab.db.repository.queryhelper.QueryResult;
@@ -111,6 +112,17 @@ public class UserRepository {
 
         return queryHelper
                 .query("UPDATE infolab.users SET description = :newDesc")
+                .where("username = :username")
+                .update(params);
+    }
+
+    public int updateUserTheme(Username username, ThemeEnum themeEnum) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("username", username.value());
+        params.put("theme", themeEnum.toString());
+
+        return queryHelper
+                .query("UPDATE infolab.users SET theme = :theme")
                 .where("username = :username")
                 .update(params);
     }

--- a/src/main/java/com/cgm/infolab/db/repository/UserRepository.java
+++ b/src/main/java/com/cgm/infolab/db/repository/UserRepository.java
@@ -35,6 +35,7 @@ public class UserRepository {
         parameters.put("username", user.getName().value());
         parameters.put("description", user.getDescription());
         parameters.put("status", user.getStatus().toString());
+        parameters.put("theme", user.getTheme().toString());
         return UserEntity.of((long)simpleJdbcInsert.executeAndReturnKey(parameters), user.getName(), user.getDescription());
     }
 

--- a/src/main/java/com/cgm/infolab/model/UserDto.java
+++ b/src/main/java/com/cgm/infolab/model/UserDto.java
@@ -1,22 +1,34 @@
 package com.cgm.infolab.model;
 
+import com.cgm.infolab.db.ID;
+
 public class UserDto {
     private String name;
     private long id;
     private String description;
     private String status;
+    private String theme;
 
     private UserDto() {
     }
-    public UserDto(String username, long id, String description, String status) {
+    public UserDto(String username, long id, String description, String status, String theme) {
         this.name = username;
         this.id = id;
         this.description = description;
         this.status = status;
+        this.theme = theme;
     }
 
     public static UserDto of(String name, long id, String description, String status) {
-        return new UserDto(name, id, description, status);
+        return new UserDto(name, id, description, status, null);
+    }
+
+    public static UserDto of(String name, long id, String description, String status, String theme) {
+        return new UserDto(name, id, description, status, theme);
+    }
+
+    public static UserDto empty() {
+        return new UserDto("", ID.None, "", "", "");
     }
 
     public long getId() {
@@ -48,5 +60,13 @@ public class UserDto {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getTheme() {
+        return theme;
+    }
+
+    public void setTheme(String theme) {
+        this.theme = theme;
     }
 }

--- a/src/main/java/com/cgm/infolab/service/UserService.java
+++ b/src/main/java/com/cgm/infolab/service/UserService.java
@@ -2,6 +2,7 @@ package com.cgm.infolab.service;
 
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.db.repository.UserRepository;
 import org.springframework.dao.DuplicateKeyException;
@@ -32,5 +33,9 @@ public class UserService {
 
     public int updateUserDescription(Username username, String newDescription) {
         return userRepository.updateUserDescription(username, newDescription);
+    }
+
+    public int updateUserTheme(Username username, ThemeEnum theme) {
+        return userRepository.updateUserTheme(username, theme);
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -20,6 +20,7 @@
             </column>
             <column name="description" type="varchar(500)" />
             <column name="status" type="char(20)"/>
+            <column name="theme" type="char(20)" />
         </createTable>
         <createIndex schemaName="infolab" tableName="users" indexName="users_index">
             <column name="username" />

--- a/src/test/java/com/cgm/infolab/UserApiTests.java
+++ b/src/test/java/com/cgm/infolab/UserApiTests.java
@@ -6,6 +6,8 @@ import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.helper.TestApiHelper;
 import com.cgm.infolab.helper.TestDbHelper;
+import com.cgm.infolab.model.UserDto;
+import org.h2.index.LinkedIndex;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -117,5 +119,15 @@ public class UserApiTests {
         List<LinkedHashMap> responseBody = testApiHelper.getFromApiForUser1("/api/users?usernames=");
 
         Assertions.assertEquals(0, responseBody.size());
+    }
+
+    @Test
+    void whenFetchingLoggedUser_theExpectedOneIsReturned() {
+        UserDto responseBody = testApiHelper.getUserFromApiForUser1("/api/users/loggeduser");
+
+        Assertions.assertEquals("user1", responseBody.getName());
+        Assertions.assertEquals("user1 desc", responseBody.getDescription());
+        Assertions.assertEquals("OFFLINE", responseBody.getStatus());
+        Assertions.assertEquals("LIGHT", responseBody.getTheme());
     }
 }

--- a/src/test/java/com/cgm/infolab/UserApiTests.java
+++ b/src/test/java/com/cgm/infolab/UserApiTests.java
@@ -2,6 +2,7 @@ package com.cgm.infolab;
 
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.helper.TestApiHelper;
 import com.cgm.infolab.helper.TestDbHelper;
@@ -49,7 +50,13 @@ public class UserApiTests {
         Arrays.stream(users)
                 .toList()
                 .forEach(
-                        userEntity -> testDbHelper.insertCustomUser(userEntity.getId(), userEntity.getName().value(), userEntity.getDescription(), UserStatusEnum.OFFLINE)
+                        userEntity -> testDbHelper.insertCustomUser(
+                                userEntity.getId(),
+                                userEntity.getName().value(),
+                                userEntity.getDescription(),
+                                UserStatusEnum.OFFLINE,
+                                ThemeEnum.LIGHT
+                        )
                 );
     }
 

--- a/src/test/java/com/cgm/infolab/UserRepositoryTests.java
+++ b/src/test/java/com/cgm/infolab/UserRepositoryTests.java
@@ -2,6 +2,7 @@ package com.cgm.infolab;
 
 import com.cgm.infolab.db.model.UserEntity;
 import com.cgm.infolab.db.model.Username;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.db.repository.UserRepository;
 import com.cgm.infolab.helper.TestDbHelper;
@@ -84,5 +85,19 @@ public class UserRepositoryTests {
 
         Assertions.assertEquals(1, rowsAffected);
         Assertions.assertEquals("Banana", user3After.getDescription());
+    }
+
+    @Test
+    void whenUpdatingUserTheme_themeIsUpdatedCorrectly() {
+        UserEntity user4Before = userRepository.getByUsername(users[4].getName()).get();
+
+        Assertions.assertEquals(ThemeEnum.LIGHT, user4Before.getTheme());
+
+        int rowsAffected = userRepository.updateUserTheme(users[4].getName(), ThemeEnum.DARK);
+
+        UserEntity user4After = userRepository.getByUsername(users[4].getName()).get();
+
+        Assertions.assertEquals(1, rowsAffected);
+        Assertions.assertEquals(ThemeEnum.DARK, user4After.getTheme());
     }
 }

--- a/src/test/java/com/cgm/infolab/helper/TestApiHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestApiHelper.java
@@ -1,6 +1,7 @@
 package com.cgm.infolab.helper;
 
 import com.cgm.infolab.model.BasicJsonDto;
+import com.cgm.infolab.model.UserDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONArray;
 import org.junit.jupiter.api.Assertions;
@@ -12,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -35,6 +37,16 @@ public class TestApiHelper {
         Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
 
         return (List<LinkedHashMap>) response.getBody();
+    }
+
+    public UserDto getUserFromApiForUser1(String url) {
+        ResponseEntity<UserDto> response = testRestTemplate
+                .withBasicAuth("user1", "password1")
+                .getForEntity(url, UserDto.class);
+
+        Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        return response.getBody();
     }
 
     public BasicJsonDto<LinkedHashMap> getFromApiForUser1WithJsonDto(String url) {

--- a/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
+++ b/src/test/java/com/cgm/infolab/helper/TestDbHelper.java
@@ -3,6 +3,7 @@ package com.cgm.infolab.helper;
 import com.cgm.infolab.db.model.ChatMessageEntity;
 import com.cgm.infolab.db.model.RoomEntity;
 import com.cgm.infolab.db.model.UserEntity;
+import com.cgm.infolab.db.model.enumeration.ThemeEnum;
 import com.cgm.infolab.db.model.enumeration.UserStatusEnum;
 import com.cgm.infolab.db.repository.RoomRepository;
 import com.cgm.infolab.db.repository.RowMappers;
@@ -104,8 +105,9 @@ public class TestDbHelper {
                 "(?, ?, ?)", timestamp, message_id, username);
     }
 
-    public void insertCustomUser(long id, String username, String description, UserStatusEnum status) {
-        jdbcTemplate.update("INSERT INTO infolab.users (id, username, description, status) VALUES (?, ?, ?, ?)", id, username, description, status.toString());
+    public void insertCustomUser(long id, String username, String description, UserStatusEnum status, ThemeEnum theme) {
+        jdbcTemplate.update("INSERT INTO infolab.users (id, username, description, status, theme) VALUES (?, ?, ?, ?, ?)",
+                id, username, description, status.toString(), theme.toString());
     }
 
     public List<ChatMessageEntity> getAllMessages() {


### PR DESCRIPTION
Nel frontend per far sì che il cambio di tema avvenisse correttamente al lancio dell'applicazione ho fatto sì che avvenga un reload della pagina. Ovviamente lo faccio solo nel caso in cui il tema sia cambiato rispetto a quello nel local storage, oppure se non c'è nel local storage il reload è fatto solo se il tema è dark (dato che quello light è di default).

Non so perché ma se provo a lanciare l'evento di cambio tema (che dal dialog del profilo funziona quasi perfettamente) cambiano colore solo metà dei componenti.

NOTA: QUESTA PR ROMPE IL DB.