### PR TITLE
Now h2 console is actually accessible

### DIFF
--- a/src/main/java/com/cgm/infolab/SecurityConfiguration.java
+++ b/src/main/java/com/cgm/infolab/SecurityConfiguration.java
@@ -9,7 +9,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.security.authorization.AuthorizationDecision;
@@ -82,9 +85,10 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain configureH2(HttpSecurity http) throws Exception{
         return http
-            .securityMatcher("/h2-console/**")
+            .securityMatcher("/*", "/h2-console/**")
             .csrf(AbstractHttpConfigurer::disable)
             .anonymous(withDefaults())
+            .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer.frameOptions().sameOrigin())
             .build();
     }
 

--- a/src/main/java/com/cgm/infolab/SecurityConfiguration.java
+++ b/src/main/java/com/cgm/infolab/SecurityConfiguration.java
@@ -83,16 +83,6 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public SecurityFilterChain configureH2(HttpSecurity http) throws Exception{
-        return http
-            .securityMatcher("/*", "/h2-console/**")
-            .csrf(AbstractHttpConfigurer::disable)
-            .anonymous(withDefaults())
-            .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer.frameOptions().sameOrigin())
-            .build();
-    }
-
-    @Bean
     public SecurityFilterChain configureAssets(HttpSecurity http) throws Exception{
         return http
             .securityMatcher(
@@ -100,7 +90,9 @@ public class SecurityConfiguration {
                 "/css/**",
                 "/js/**"
             )
+            .csrf(AbstractHttpConfigurer::disable)
             .anonymous(withDefaults())
+            .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer.frameOptions().sameOrigin())
             .build();
     }
 

--- a/src/main/java/com/cgm/infolab/SecurityConfiguration.java
+++ b/src/main/java/com/cgm/infolab/SecurityConfiguration.java
@@ -82,6 +82,10 @@ public class SecurityConfiguration {
             .build();
     }
 
+    // IMPORTANT NOTE: There is not a SecurityFilterChain for /h2-console/** paths because it never gets triggered
+    //  making it misleading.
+    // The chain that actually gets triggered is the one with /* path.
+
     @Bean
     public SecurityFilterChain configureAssets(HttpSecurity http) throws Exception{
         return http

--- a/src/test/java/com/cgm/infolab/SecurityTests.java
+++ b/src/test/java/com/cgm/infolab/SecurityTests.java
@@ -106,19 +106,7 @@ public class SecurityTests {
             .andExpect(status().isForbidden());
     }
 
-    @Test
-    void getToH2WithoutUserShouldBeOk() throws Exception {
-        client
-            .perform(get("/h2-console/"))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    void postingToH2WithoutUserShouldBeOk() throws Exception {
-        client
-            .perform(post("/h2-console/"))
-            .andExpect(status().isOk());
-    }
+    // TODO: put comment
 
     @Test
     @WithMockUser(username = "user1", password = "password1")

--- a/src/test/java/com/cgm/infolab/SecurityTests.java
+++ b/src/test/java/com/cgm/infolab/SecurityTests.java
@@ -20,6 +20,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+// IMPORTANT NOTE: There is not any test for h2-console endpoint because it would be misleading since it would pass even if
+//  the h2-console was not accessible. For some reason the test activated the expected security filter, while the
+//  actual h2 requests do not.
+
 @WebMvcTest(controllers = {SecurityTestsController.class})
 @Import({SecurityConfiguration.class, CsrfController.class, TestSecurityConfiguration.class})
 @ActiveProfiles(ProfilesConstants.TEST)
@@ -105,8 +109,6 @@ public class SecurityTests {
             .perform(post("/chat/test"))
             .andExpect(status().isForbidden());
     }
-
-    // TODO: put comment
 
     @Test
     @WithMockUser(username = "user1", password = "password1")

--- a/src/test/java/com/cgm/infolab/controller/SecurityTestsController.java
+++ b/src/test/java/com/cgm/infolab/controller/SecurityTestsController.java
@@ -61,10 +61,4 @@ public class SecurityTestsController {
     public String chatPost(){
         return "chatPost requires authentication";
     }
-
-    @RequestMapping("/h2-console/")
-    public String h2(){
-        return "chatPost requires authentication";
-    }
-
 }


### PR DESCRIPTION
Non c'era modo di testare col codice il funzionamento della console.
L'endpoint /h2-console/ è accessibile e anche se si aggiunge un sub endpoint (ad esempio /h2-console/test) e lo si chiama in post risulta accessibile.

Closes #378 